### PR TITLE
Update documentation for LegifranceClient initialization and rename set_api_keys to update_api_keys

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -16,12 +16,35 @@ Voir le [guide officiel](https://piste.gouv.fr/en/help-center/guide) pour plus d
 
 ## Configuration des clés API
 
-Variables d'environnement ou fichier `.env` :
+Deux options pour configurer vos identifiants API :
 
-```
+### 1. Variables d’environnement (ou `.env`)
+
+```bash
 LEGIFRANCE_CLIENT_ID=votre_client_id
 LEGIFRANCE_CLIENT_SECRET=votre_client_secret
 ```
+
+Le client s’initialise automatiquement :
+
+```python
+from pylegifrance import LegifranceClient
+
+client = LegifranceClient()
+```
+
+### 2. Configuration manuelle
+
+Utile si vos clés proviennent d’un vault ou d’un système externe :
+
+```python
+from pylegifrance import LegifranceClient
+from pylegifrance.config import ApiConfig
+
+client = LegifranceClient(ApiConfig(client_id="...", client_secret="..."))
+```
+
+⚠️ Les identifiants sont obligatoires dès l’instanciation, sinon une erreur est levée.
 
 ## Exemples d'utilisation
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -63,10 +63,30 @@ Recherche dans la jurisprudence (en développement).
 
 ```python
 class LegifranceClient:
-    def set_api_keys(self, legifrance_api_key=None, legifrance_api_secret=None)
+    def __init__(config: Optional[ApiConfig] = None)
+    def update_api_keys(self, legifrance_api_key=None, legifrance_api_secret=None)
     def call_api(self, route: str, data: str)
     def ping(self, route: str = "consult/ping")
     def get(self, route: str)
 ```
 
 Gère l'authentification et les appels à l'API Legifrance.
+
+### ApiConfig
+
+```python
+class ApiConfig:
+    def __init__(
+        client_id: str,
+        client_secret: str,
+        token_url: str = "...",
+        api_url: str = "...",
+        connect_timeout: float = 3.05,
+        read_timeout: float = 27.0,
+    )
+
+    @classmethod
+    def from_env() -> "ApiConfig"
+```
+
+Gère la configuration d’accès à l’API (identifiants, URLs, timeouts).

--- a/pylegifrance/client.py
+++ b/pylegifrance/client.py
@@ -59,11 +59,11 @@ class LegifranceClient:
 
         configure_session_timeouts(self.session, config)
 
-    def set_api_keys(
+    def update_api_keys(
         self, client_id: Optional[str] = None, client_secret: Optional[str] = None
     ) -> None:
         """
-        Set or update the API keys for the client.
+        Update the API keys for the client.
 
         If keys are provided, they replace the current values.
         If keys are not provided, the method attempts to retrieve them

--- a/pylegifrance/test/README.md
+++ b/pylegifrance/test/README.md
@@ -24,6 +24,15 @@ LEGIFRANCE_CLIENT_ID=your_client_id
 LEGIFRANCE_CLIENT_SECRET=your_client_secret
 ```
 
+> 💡 Alternativement, vous pouvez passer les identifiants directement via `ApiConfig` dans votre code de test :
+
+```python
+from pylegifrance import LegifranceClient
+from pylegifrance.config import ApiConfig
+
+client = LegifranceClient(ApiConfig(client_id="your_client_id", client_secret="your_client_secret"))
+```
+
 Ces identifiants sont nécessaires pour que les tests API fonctionnent correctement.
 
 ## Exécution des Tests

--- a/pylegifrance/test/test_client.py
+++ b/pylegifrance/test/test_client.py
@@ -70,6 +70,31 @@ def test_client_initialization_without_env_vars(monkeypatch):
     assert "Required environment variables" in str(excinfo.value)
 
 
+def test_update_api_keys_with_valid_credentials(monkeypatch):
+    """
+    Test that update_api_keys replaces invalid credentials with valid ones from env.
+    """
+    # Given invalid credentials
+    bad_config = ApiConfig(client_id="fake_id", client_secret="fake_secret")
+    client = LegifranceClient(config=bad_config)
+
+    # The initial ping should fail
+    with pytest.raises(Exception):
+        client.ping()
+
+    # Simulate using other credentials
+    load_dotenv()
+    client_id = os.getenv("LEGIFRANCE_CLIENT_ID")
+    client_secret = os.getenv("LEGIFRANCE_CLIENT_SECRET")
+    
+    client.update_api_keys(client_id=client_id, client_secret=client_secret)
+
+    # Now ping should succeed
+    assert client.ping(), "Ping should succeed after updating with valid API keys"
+
+    client.close()
+
+
 def test_api_request(api_client):
     """
     Test that an API request works correctly.


### PR DESCRIPTION
close #15

* document ApiConfig usage and initialization examples

* refactor: rename set_api_keys to update_api_keys and add corresponding test

* test: Simulating other creds usage