### PR TITLE
Fix Code name filter, add missing code (CPC), add new filters for juri search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:
@@ -16,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Common Environment
         uses: ./.github/actions/setup

--- a/pylegifrance/fonds/code.py
+++ b/pylegifrance/fonds/code.py
@@ -280,9 +280,11 @@ class CodeSearchBuilder:
             raise ValueError(f"Type de fond non supporté: {self.fond}")
 
         # Exécuter la requête
-        response = self.api.call_api(
-            "search", request.model_dump(by_alias=True, mode="json")
-        )
+        request_dict = request.model_dump(by_alias=True, mode="json")
+        if hasattr(request.recherche, 'to_generated'):
+            request_dict["recherche"] = request.recherche.to_generated(self.fond).model_dump(by_alias=True, mode="json")
+
+        response = self.api.call_api("search", request_dict)
 
         results = []
         if response:

--- a/pylegifrance/models/code/enum.py
+++ b/pylegifrance/models/code/enum.py
@@ -5,6 +5,7 @@ class NomCode(str, Enum):
     """Énumération des noms officiels des codes juridiques français."""
 
     CC = "Code civil"
+    CPC = "Code de procédure civile"
     CCOM = "Code de commerce"
     CPD = "Code pénal"
     CDC = "Code des communes"

--- a/pylegifrance/models/code/search.py
+++ b/pylegifrance/models/code/search.py
@@ -118,15 +118,21 @@ class NomCodeFiltre(BaseModel):
         min_length=1,
     )
 
-    def to_generated(self) -> FiltreDTO:
+    def to_generated(self, fond: str = "CODE_DATE") -> FiltreDTO:
         """Convertit le filtre vers un objet DTO pour l'API.
 
         Returns:
             FiltreDTO: Objet de transfert avec les valeurs converties
                 en chaînes de caractères pour l'API Légifrance.
         """
+        
+        if fond == "CODE_ETAT":
+            facette_value = "TEXT_NOM_CODE"
+        else:
+            facette_value = "NOM_CODE"
+        
         return FiltreDTO(
-            facette=self.facette.value,
+            facette=facette_value,
             valeurs=[valeur.value for valeur in self.valeurs],
             dates=None,
             singleDate=None,
@@ -277,11 +283,19 @@ class CodeSearchCriteria(BaseModel):
         description="Type de pagination à utiliser",
     )
 
-    def to_generated(self) -> RechercheSpecifiqueDTO:
+    def to_generated(self, fond: str = "CODE_DATE") -> RechercheSpecifiqueDTO:
         """Convertit vers le DTO pour l'API."""
+        
+        filtres_converted = []
+        for f in self.filtres:
+            if isinstance(f, NomCodeFiltre):
+                filtres_converted.append(f.to_generated(fond))
+            else:
+                filtres_converted.append(f.to_generated())
+        
         return RechercheSpecifiqueDTO(
             champs=[c.to_generated() for c in self.champs],
-            filtres=[f.to_generated() for f in self.filtres],
+            filtres=filtres_converted,
             pageNumber=self.page_number,
             pageSize=self.page_size,
             operateur=self.operateur.to_generated(),

--- a/pylegifrance/models/juri/search.py
+++ b/pylegifrance/models/juri/search.py
@@ -59,6 +59,11 @@ class SearchRequest(PyLegifranceBaseModel):
         description="Date facet to filter on (DATE_DECISION, DATE_PUBLI, etc.)"
     )
     
+    formation: Optional[List[str]] = Field(
+        default=None, 
+        description="Formation filter (e.g., 'Chambre sociale', 'Première chambre civile', 'Chambre criminelle')"
+    )
+    
     @validator('date_start', 'date_end')
     def validate_date_format(cls, v):
         """Validate date format is ISO YYYY-MM-DD."""
@@ -119,6 +124,10 @@ class SearchRequest(PyLegifranceBaseModel):
         # Add date filter if specified
         if self.date_start and self.date_end:
             filters.append(self._create_date_filter())
+            
+        # Add formation filter if specified
+        if self.formation:
+            filters.append(self._create_formation_filter())
 
         return filters
 
@@ -156,6 +165,16 @@ class SearchRequest(PyLegifranceBaseModel):
                 start=datetime.fromisoformat(self.date_start),
                 end=datetime.fromisoformat(self.date_end)
             ),
+            singleDate=None,
+            multiValeurs=None,
+        )
+    
+    def _create_formation_filter(self) -> FiltreDTO:
+        """Create formation filter."""
+        return FiltreDTO(
+            facette=FacettesJURI.CASSATION_FORMATION.value,
+            valeurs=self.formation,
+            dates=None,
             singleDate=None,
             multiValeurs=None,
         )

--- a/pylegifrance/models/juri/search.py
+++ b/pylegifrance/models/juri/search.py
@@ -64,6 +64,11 @@ class SearchRequest(PyLegifranceBaseModel):
         description="Formation filter (e.g., 'Chambre sociale', 'Première chambre civile', 'Chambre criminelle')"
     )
     
+    cour_appel: Optional[List[str]] = Field(
+        default=None, 
+        description="Court of appeal location filter (only for 'Juridictions d'appel')"
+    )
+    
     @validator('date_start', 'date_end')
     def validate_date_format(cls, v):
         """Validate date format is ISO YYYY-MM-DD."""
@@ -128,6 +133,10 @@ class SearchRequest(PyLegifranceBaseModel):
         # Add formation filter if specified
         if self.formation:
             filters.append(self._create_formation_filter())
+        
+        # Add court of appeal filter if specified  
+        if self.cour_appel and self.juridiction_judiciaire and "Juridictions d'appel" in self.juridiction_judiciaire:
+            filters.append(self._create_cour_appel_filter())
 
         return filters
 
@@ -174,6 +183,15 @@ class SearchRequest(PyLegifranceBaseModel):
         return FiltreDTO(
             facette=FacettesJURI.CASSATION_FORMATION.value,
             valeurs=self.formation,
+            dates=None,
+            singleDate=None,
+            multiValeurs=None,
+        )
+    
+    def _create_cour_appel_filter(self) -> FiltreDTO:
+        return FiltreDTO(
+            facette=FacettesJURI.APPEL_SIEGE_APPEL.value,
+            valeurs=self.cour_appel,
             dates=None,
             singleDate=None,
             multiValeurs=None,


### PR DESCRIPTION
- When searching in CODE_ETAT fond, the filter name is "TEXT_NOM_CODE", not "NOM_CODE": fixed
- CPC (Code de procédure civile) was missing from NomCode enum: fixed
- New filter for juri search: date_start, date_end, formation, cour_appel: added