### PR TITLE
feat(juri): add url property to JuriDecision mirroring Article model

### DIFF
--- a/pylegifrance/fonds/juri.py
+++ b/pylegifrance/fonds/juri.py
@@ -17,6 +17,14 @@ from pylegifrance.utils import EnumEncoder
 HTTP_OK = 200
 CITATION_TYPE = "CITATION"
 
+# Supported Legifrance case law identifier prefixes. JURITEXT is used for
+# judicial decisions (Cour de cassation, cours d'appel, tribunaux judiciaires)
+# and CETATEXT for administrative case law (Conseil d'Etat, tribunaux
+# administratifs). Both resolve under the same /juri/id/ path on
+# legifrance.gouv.fr.
+JURI_URL_ID_PREFIXES: tuple[str, ...] = ("JURITEXT", "CETATEXT")
+JURI_URL_TEMPLATE = "https://www.legifrance.gouv.fr/juri/id/{decision_id}"
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,6 +50,39 @@ class JuriDecision:
     def id(self) -> str | None:
         """Récupère l'identifiant de la décision."""
         return self._decision.id
+
+    @property
+    def url(self) -> str | None:
+        """Construit l'URL Legifrance officielle de la décision.
+
+        L'URL est dérivée de l'identifiant de la décision en suivant le
+        schéma canonique ``https://www.legifrance.gouv.fr/juri/id/{id}``.
+        Ce même chemin résout les décisions judiciaires (``JURITEXT...``)
+        et les décisions administratives (``CETATEXT...``).
+
+        Reflète le comportement d'auto-génération d'URL déjà présent sur
+        :class:`pylegifrance.models.code.models.Article`, afin que les
+        consommateurs (notamment les agents LLM) disposent toujours d'une
+        URL vérifiable et puissent distinguer les citations authentiques
+        des fabrications.
+
+        Returns:
+            L'URL canonique de consultation sur legifrance.gouv.fr, ou
+            ``None`` si l'identifiant est manquant ou ne correspond pas à
+            un préfixe reconnu (JURITEXT ou CETATEXT). Retourne ``None``
+            plutôt qu'une URL malformée afin de ne pas induire les
+            consommateurs en erreur.
+
+        Examples:
+            >>> decision.url
+            'https://www.legifrance.gouv.fr/juri/id/JURITEXT000027546700'
+        """
+        decision_id = self._decision.id
+        if not decision_id:
+            return None
+        if not decision_id.startswith(JURI_URL_ID_PREFIXES):
+            return None
+        return JURI_URL_TEMPLATE.format(decision_id=decision_id)
 
     @property
     def cid(self) -> Cid | None:

--- a/tests/integration/fonds/juri/steps.py
+++ b/tests/integration/fonds/juri/steps.py
@@ -77,6 +77,16 @@ def verify_essential_information(context):
         )
         assert decision.id is not None, "Chaque décision doit avoir un ID"
 
+        # L'URL canonique Legifrance doit être exposée lorsque l'ID
+        # porte un préfixe reconnu (JURITEXT / CETATEXT).
+        if decision.id.startswith(("JURITEXT", "CETATEXT")):
+            assert decision.url is not None, (
+                "Chaque décision avec un ID JURITEXT/CETATEXT doit exposer une URL"
+            )
+            assert decision.url == (
+                f"https://www.legifrance.gouv.fr/juri/id/{decision.id}"
+            ), "L'URL générée doit suivre le schéma canonique Legifrance"
+
         # Au moins une des informations essentielles doit être présente
         essential_info_present = any(
             [

--- a/tests/unit/fonds/test_juri_decision.py
+++ b/tests/unit/fonds/test_juri_decision.py
@@ -1,0 +1,81 @@
+"""Unit tests for the :class:`pylegifrance.fonds.juri.JuriDecision` wrapper.
+
+These tests focus on behaviour that does not require the Legifrance API,
+notably the :pyattr:`JuriDecision.url` auto-generation that mirrors the
+canonical URL logic already present on :class:`Article`.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pylegifrance.fonds.juri import JuriDecision
+from pylegifrance.models.juri.models import Decision
+
+
+def _make_decision(decision_id: str | None) -> JuriDecision:
+    """Build a :class:`JuriDecision` around a minimally populated model."""
+    decision = Decision(id=decision_id) if decision_id is not None else Decision()
+    client = MagicMock()
+    return JuriDecision(decision=decision, client=client)
+
+
+class TestJuriDecisionUrl:
+    """Auto-generated Legifrance URL on :class:`JuriDecision`."""
+
+    def test_url_from_juritext_id(self):
+        """A JURITEXT id yields the canonical Legifrance consultation URL."""
+        decision = _make_decision("JURITEXT000027546700")
+
+        assert (
+            decision.url
+            == "https://www.legifrance.gouv.fr/juri/id/JURITEXT000027546700"
+        )
+
+    def test_url_from_cetatext_id(self):
+        """A CETATEXT id (Conseil d'Etat) also resolves under /juri/id/."""
+        decision = _make_decision("CETATEXT000007422435")
+
+        assert (
+            decision.url
+            == "https://www.legifrance.gouv.fr/juri/id/CETATEXT000007422435"
+        )
+
+    def test_url_is_none_when_id_is_none(self):
+        """A decision with no id must not emit a malformed URL."""
+        decision = _make_decision(None)
+
+        assert decision.url is None
+
+    def test_url_is_none_when_id_is_empty(self):
+        """An empty id must yield ``None`` rather than a dangling URL."""
+        decision = _make_decision("")
+
+        assert decision.url is None
+
+    def test_url_is_none_for_unknown_prefix(self):
+        """Identifiers with unrecognised prefixes must not be URL-ified.
+
+        Only JURITEXT and CETATEXT are known to resolve under
+        ``/juri/id/`` on legifrance.gouv.fr. Anything else would produce
+        a broken link and is therefore refused.
+        """
+        decision = _make_decision("LEGIARTI000006419292")
+
+        assert decision.url is None
+
+    @pytest.mark.parametrize(
+        "decision_id",
+        [
+            "JURITEXT000041234567",
+            "JURITEXT000000254716",
+            "CETATEXT000007422435",
+        ],
+    )
+    def test_url_is_prefixed_with_legifrance_host(self, decision_id):
+        """Every generated URL targets the official Legifrance host."""
+        decision = _make_decision(decision_id)
+
+        assert decision.url is not None
+        assert decision.url.startswith("https://www.legifrance.gouv.fr/juri/id/")
+        assert decision.url.endswith(decision_id)


### PR DESCRIPTION
## Summary
- Add a `url` property to `JuriDecision` that auto-constructs the canonical Legifrance URL from the decision id (`JURITEXT...` / `CETATEXT...`).
- Mirrors the existing URL logic on `Article` at `pylegifrance/models/code/models.py:466-473`.
- Returns `None` when the id is missing, empty, or carries an unrecognised prefix, so consumers never receive a malformed URL.

## Motivation
Downstream LLM agent consumers (e.g. CrewAI Legal Researcher agents in `analysecontrat-core`) depend on having a verifiable URL in every returned result to distinguish real citations from fabrications. The current asymmetry between `Article` (has URL) and `JuriDecision` (no URL) was observed to push agents toward hallucinating plausible-but-fake case-law URLs on `courdecassation.fr`. This fix closes that asymmetry at the library level so every pylegifrance consumer benefits, not just the one that noticed.

## URL scheme
Verified via Wayback Machine CDX — both JURITEXT (judicial) and CETATEXT (Conseil d'Etat) ids resolve under the same path:
```
https://www.legifrance.gouv.fr/juri/id/{decision_id}
```
Only these two prefixes are URL-ified today; any other id shape returns `None` (documented in the property docstring).

## Test plan
- [x] Unit test: `JuriDecision(id="JURITEXT000027546700")` yields `https://www.legifrance.gouv.fr/juri/id/JURITEXT000027546700`
- [x] Unit test: CETATEXT id resolves under the same path
- [x] Unit test: `id=None` yields `url=None`
- [x] Unit test: `id=""` yields `url=None`
- [x] Unit test: unknown prefix (e.g. `LEGIARTI...`) yields `url=None`
- [x] Parametrized test: generated URLs are always prefixed with `https://www.legifrance.gouv.fr/juri/id/`
- [x] Integration BDD step extended to assert URL presence on live results
- [x] `uv run pytest tests/unit tests/test_client.py` — 19 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uvx ty check pylegifrance/fonds/juri.py` clean (note: full repo `ty check` has 30 pre-existing diagnostics unrelated to this change)

## References
- Article URL pattern: `pylegifrance/models/code/models.py:466-473`
- Legifrance URL scheme: `https://www.legifrance.gouv.fr/juri/id/{decision_id}`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>