### PR TITLE
feat(kali): add façade for conventions collectives

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -149,3 +149,22 @@
   frontmatter `pr:` / `url: pulls/<n>`).
 - L'entrée du log de [2026-04-17] « LLM transparency workflow »
   n'est pas réécrite (log append-only, cf. @docs/CLAUDE.md § 10).
+
+## [2026-04-20] ingest | Façade KALI (conventions collectives)
+
+- Façade `pylegifrance/fonds/kali.py` ajoutée, exposant `KaliAPI`,
+  `ConventionCollective`, `TexteKali`. Couvre `POST /consult/kaliCont`,
+  `/consult/kaliContIdcc`, `/consult/kaliText`, `/consult/kaliArticle`,
+  `/consult/kaliSection`, et la recherche `/search` avec `fond: "KALI"`.
+- Modèles domaine sous `pylegifrance/models/kali/` : `enum.py`
+  (`TypeChampKali`, `SortKali`, `FacettesKALI`), `search.py`
+  (`SearchRequest` → `SearchRequestDTO`), `models.py` (wrappers
+  Pydantic autour de `ConsultKaliContResponse` /
+  `ConsultKaliTextResponse`).
+- Tests unitaires sous `tests/unit/fonds/test_kali.py` (17 cas,
+  ciblent la frontière `call_api` sans HTTP réel).
+- Nouvelle page `entities/fond-kali.md`, carte ajoutée au catalogue
+  `index.mdx`. Pas de `references/kali.md` pour l'instant (YAGNI,
+  à créer quand l'API se stabilise).
+- KALI n'exposant pas d'endpoint `/version` / `/versions`, aucun
+  équivalent à `.at(date)` / `.versions()` n'est prévu.

--- a/docs/src/content/docs/entities/fond-kali.md
+++ b/docs/src/content/docs/entities/fond-kali.md
@@ -1,0 +1,117 @@
+---
+title: Fond KALI
+description: Façade pour consulter et rechercher les conventions collectives nationales (KALI).
+sidebar:
+  order: 6
+sources:
+  - "@docs/raw/legifrance/description-des-tris-et-filtres-de-l-api.md"
+  - "@docs/raw/legifrance/exemples-d-utilisation-de-l-api.md"
+related:
+  - /concepts/fond-facade
+  - /entities/fond-code
+  - /entities/fond-juri
+updated: 2026-04-20
+---
+
+La classe `KaliAPI` (dans `pylegifrance/fonds/kali.py`) est la façade qui
+expose les endpoints du fond **KALI** : les conventions collectives
+nationales étendues, leurs accords et avenants.
+
+## Portée
+
+Le fond KALI organise les conventions collectives sur deux niveaux :
+
+- un **conteneur** (`KALICONT...`), identifié par un numéro IDCC, qui
+  regroupe une convention collective dans son ensemble ;
+- des **textes** (`KALITEXT...`) — texte de base, avenants, accords —
+  qui sont les unités réellement consultables, avec leurs sections
+  (`KALISCTA...`) et articles (`KALIARTI...`).
+
+KALI n'expose pas d'endpoint `/version` ni `/versions` : il n'y a donc
+pas d'équivalent à `.at(date)` ou `.versions()` comme sur le fond LODA.
+
+## Usage
+
+```python
+from pylegifrance import LegifranceClient
+from pylegifrance.fonds.kali import KaliAPI
+from pylegifrance.models.kali.search import SearchRequest
+from pylegifrance.models.kali.enum import TypeChampKali, SortKali
+
+client = LegifranceClient(client_id="...", client_secret="...")
+kali = KaliAPI(client)
+
+# Convention par numéro IDCC
+ccn = kali.fetch_by_idcc("1261")
+print(ccn.titre, ccn.texte_base_ids)
+
+# Convention par identifiant KALICONT
+ccn = kali.fetch_container("KALICONT000005635384")
+
+# Texte (base, avenant...) par identifiant KALITEXT
+texte = kali.fetch_text("KALITEXT000005677408")
+
+# Dispatcher unique basé sur le préfixe
+obj = kali.fetch("KALIARTI000005833238")  # -> TexteKali (endpoint kaliArticle)
+
+# Recherche libre (hydratée vers des ConventionCollective)
+resultats = kali.search("santé prévoyance")
+
+# Recherche structurée
+req = SearchRequest(
+    search="2098",
+    field=TypeChampKali.IDCC,
+    idcc="2098",
+    sort=SortKali.SIGNATURE_DATE_DESC,
+)
+resultats = kali.search(req)
+```
+
+## Composants exposés
+
+- `KaliAPI.fetch_container(id)` → `ConventionCollective` (`POST /consult/kaliCont`).
+- `KaliAPI.fetch_by_idcc(idcc)` → `ConventionCollective` (`POST /consult/kaliContIdcc`).
+- `KaliAPI.fetch_text(id)` → `TexteKali` (`POST /consult/kaliText`).
+- `KaliAPI.fetch_article(id)` → `TexteKali` parent (`POST /consult/kaliArticle`).
+- `KaliAPI.fetch_section(id)` → `TexteKali` parent (`POST /consult/kaliSection`).
+- `KaliAPI.fetch(id)` → dispatcher par préfixe (`KALICONT` / `KALITEXT` /
+  `KALIARTI` / `KALISCTA`).
+- `KaliAPI.search(query)` → `list[ConventionCollective]` via `POST /search`
+  avec `fond: "KALI"`.
+
+## Modèle de recherche
+
+`SearchRequest` (dans `pylegifrance/models/kali/search.py`) génère un
+`SearchRequestDTO` au format attendu par l'endpoint `/search`. Champs
+pris en charge :
+
+| Champ | Utilisation |
+|---|---|
+| `search` | Texte libre |
+| `field` | `ALL`, `TITLE`, `IDCC`, `MOTS_CLES`, `ARTICLE` |
+| `search_type` | `EXACTE`, `TOUS_LES_MOTS_DANS_UN_CHAMP`… |
+| `sort` | `PERTINENCE`, `SIGNATURE_DATE_DESC`/`_ASC`, `MODIFICATION_DATE_DESC` |
+| `idcc` | Filtre IDCC (facette `IDCC`) |
+| `legal_status` | Filtre état juridique (facette `LEGAL_STATUS`) — voir ci-dessous |
+| `date_signature_start` / `date_signature_end` | Plage date de signature (facette `DATE_SIGNATURE`) |
+
+Par défaut, `legal_status` est pré-rempli à
+`["VIGUEUR", "VIGUEUR_ETEN", "VIGUEUR_NON_ETEN"]` : seules les
+conventions **en vigueur** (étendues ou non) remontent. Passer
+`legal_status=None` ou `legal_status=[]` désactive ce filtre et
+retourne également les textes abrogés / périmés.
+
+Les autres facettes documentées (`ACTIVITE`, `NUM_TEXTE_CITE`,
+`NOM_CODE_CITE`…) n'ont pas été câblées — à ajouter à la demande.
+
+## Voir aussi
+
+- [Fond facade](/pylegifrance/concepts/fond-facade/) — pourquoi les
+  façades et les modèles sont séparés.
+- Raw officiel : `docs/raw/legifrance/description-des-tris-et-filtres-de-l-api.md`
+  (section KALI et `consult-kali*`).
+
+:::caution
+Il est de la responsabilité exclusive de l'utilisateur·rice de vérifier
+que les informations renvoyées par l'API sont pertinentes et à jour.
+:::

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -41,6 +41,9 @@ pour les conventions de contribution.
   <Card title="Fond LODA" icon="list-format">
     [Lois / ordonnances / décrets / arrêtés](/pylegifrance/entities/fond-loda/)
   </Card>
+  <Card title="Fond KALI" icon="seti:notebook">
+    [Conventions collectives nationales](/pylegifrance/entities/fond-kali/)
+  </Card>
   <Card title="Article" icon="pencil">
     [Modèle Article](/pylegifrance/entities/article/)
   </Card>

--- a/pylegifrance/fonds/kali.py
+++ b/pylegifrance/fonds/kali.py
@@ -1,0 +1,413 @@
+"""Façade KALI — conventions collectives nationales.
+
+Le fond KALI regroupe les conventions collectives étendues et leurs
+accords. Les objets sont organisés en deux niveaux :
+
+- le **conteneur** (``KALICONT...``) qui représente une convention
+  collective au sens large, identifiée par un numéro IDCC ;
+- les **textes** (``KALITEXT...``) — texte de base, avenants, accords —
+  qui sont les unités réellement consultables, avec sections et
+  articles.
+
+Cette façade expose un :class:`KaliAPI` mince (inspiré de
+:class:`pylegifrance.fonds.juri.JuriAPI`) et deux wrappers de domaine,
+:class:`ConventionCollective` et :class:`TexteKali`. KALI n'exposant pas
+d'endpoint ``versions`` / ``version/at``, aucun équivalent à
+``.at(date)`` ou ``.versions()`` n'est fourni.
+
+Endpoints de consultation couverts (voir
+``docs/raw/legifrance/description-des-tris-et-filtres-de-l-api.md``
+section *Présentation du Consult*) :
+
+- ``POST /consult/kaliCont`` — conteneur par identifiant ``KALICONT``.
+- ``POST /consult/kaliContIdcc`` — conteneur par numéro IDCC.
+- ``POST /consult/kaliText`` — texte par identifiant ``KALITEXT``.
+- ``POST /consult/kaliSection`` — texte parent d'une section.
+- ``POST /consult/kaliArticle`` — texte parent d'un article.
+"""
+
+import json
+import logging
+import re
+from typing import Any
+
+from pylegifrance.client import LegifranceClient
+from pylegifrance.models.generated.model import (
+    ConsultKaliContResponse,
+    ConsultKaliTextResponse,
+    KaliContConsultIdccRequest,
+    KaliContConsultRequest,
+    KaliTextConsultArticleRequest,
+    KaliTextConsultRequest,
+    KaliTextConsultSectionRequest,
+)
+from pylegifrance.models.kali.search import SearchRequest
+from pylegifrance.utils import EnumEncoder
+
+HTTP_OK = 200
+
+KALI_CONT_PREFIX = "KALICONT"
+KALI_TEXT_PREFIX = "KALITEXT"
+KALI_ARTI_PREFIX = "KALIARTI"
+KALI_SCTA_PREFIX = "KALISCTA"
+KALI_PREFIXES: tuple[str, ...] = (
+    KALI_CONT_PREFIX,
+    KALI_TEXT_PREFIX,
+    KALI_ARTI_PREFIX,
+    KALI_SCTA_PREFIX,
+)
+
+_IDCC_PATTERN: re.Pattern[str] = re.compile(r"^\d{1,5}$")
+
+logger = logging.getLogger(__name__)
+
+
+class ConventionCollective:
+    """Conteneur d'une convention collective (niveau IDCC)."""
+
+    def __init__(self, data: ConsultKaliContResponse, client: LegifranceClient):
+        self._data = data
+        self._client = client
+
+    @property
+    def id(self) -> str | None:
+        """Identifiant ``KALICONT...`` du conteneur."""
+        return self._data.id
+
+    @property
+    def titre(self) -> str | None:
+        return self._data.titre
+
+    @property
+    def idcc(self) -> str | None:
+        """Numéro IDCC (ex: ``"1261"``), si présent dans la réponse."""
+        return self._data.num
+
+    @property
+    def nature(self) -> str | None:
+        return self._data.nature
+
+    @property
+    def numero_texte(self) -> str | None:
+        """Libellé ``"IDCC <n>"`` utilisé par la DILA."""
+        return self._data.numero_texte
+
+    @property
+    def activites_pro(self) -> list[str] | None:
+        return self._data.activite_pro
+
+    @property
+    def categorisation(self) -> list[str] | None:
+        return self._data.categorisation
+
+    @property
+    def texte_base_ids(self) -> list[str] | None:
+        """Identifiants ``KALITEXT...`` des textes de base associés."""
+        return self._data.texte_base_id
+
+    @property
+    def sections(self) -> list:
+        return self._data.sections or []
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._data.model_dump(by_alias=True)
+
+    def to_markdown(self) -> str:
+        parts: list[str] = [
+            f"## {self.titre or self.id or 'Convention collective'}",
+            "",
+        ]
+        if self.idcc:
+            parts.append(f"**IDCC**: {self.idcc}")
+        if self.numero_texte:
+            parts.append(f"**Numéro**: {self.numero_texte}")
+        if self.nature:
+            parts.append(f"**Nature**: {self.nature}")
+        if self.activites_pro:
+            parts.append(f"**Activités**: {', '.join(self.activites_pro)}")
+        if self.id:
+            parts.append(f"**Référence**: {self.id}")
+        return "\n".join(parts)
+
+    def __repr__(self) -> str:
+        return (
+            f"ConventionCollective(id={self.id}, idcc={self.idcc}, titre={self.titre})"
+        )
+
+
+class TexteKali:
+    """Texte individuel du fond KALI (texte de base, avenant, accord)."""
+
+    def __init__(self, data: ConsultKaliTextResponse, client: LegifranceClient):
+        self._data = data
+        self._client = client
+
+    @property
+    def container_id(self) -> str | None:
+        """Identifiant ``KALICONT`` du conteneur parent, si disponible.
+
+        ``ConsultKaliTextResponse`` n'expose pas d'``id`` propre (le
+        schéma DILA l'implique via le contexte d'appel) ; seul
+        ``id_conteneur`` est disponible pour remonter au conteneur
+        parent.
+        """
+        return self._data.id_conteneur
+
+    @property
+    def titre(self) -> str | None:
+        return self._data.title
+
+    @property
+    def nor(self) -> str | None:
+        return self._data.nor
+
+    @property
+    def etat(self) -> str | None:
+        return self._data.etat
+
+    @property
+    def type_texte(self) -> str | None:
+        """Type de texte (``TEXTE_BASE``, ``AVENANT``...)."""
+        return self._data.type_texte
+
+    @property
+    def nature(self) -> str | None:
+        return self._data.nature
+
+    @property
+    def date_signature(self):
+        return self._data.date_texte
+
+    @property
+    def date_parution(self):
+        return self._data.date_parution
+
+    @property
+    def texte_numero(self) -> str | None:
+        return self._data.text_number
+
+    @property
+    def signataires(self):
+        return self._data.signataires
+
+    @property
+    def articles(self) -> list:
+        return self._data.articles or []
+
+    @property
+    def sections(self) -> list:
+        return self._data.sections or []
+
+    @property
+    def visas_html(self) -> str | None:
+        return self._data.visas_html
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._data.model_dump(by_alias=True)
+
+    def to_markdown(self) -> str:
+        parts: list[str] = [f"## {self.titre or 'Texte KALI'}", ""]
+        if self.etat:
+            parts.append(f"**Statut**: {self.etat}")
+        if self.type_texte:
+            parts.append(f"**Type**: {self.type_texte}")
+        if self.nor:
+            parts.append(f"**NOR**: {self.nor}")
+        if self.texte_numero:
+            parts.append(f"**Numéro**: {self.texte_numero}")
+        if self.date_signature:
+            parts.append(f"**Signé le**: {self.date_signature}")
+        if self.date_parution:
+            parts.append(f"**Paru le**: {self.date_parution}")
+        if self.container_id:
+            parts.append(f"**Conteneur**: {self.container_id}")
+        return "\n".join(parts)
+
+    def __repr__(self) -> str:
+        return (
+            "TexteKali("
+            f"titre={self.titre}, etat={self.etat}, "
+            f"conteneur={self.container_id})"
+        )
+
+
+class KaliAPI:
+    """API haut niveau pour le fond KALI."""
+
+    def __init__(self, client: LegifranceClient):
+        self._client = client
+
+    def fetch_container(self, kali_id: str) -> ConventionCollective | None:
+        """Récupère un conteneur par son identifiant ``KALICONT``.
+
+        Wraps ``POST /consult/kaliCont``.
+        """
+        if not kali_id or not kali_id.strip():
+            raise ValueError("kali_id ne peut pas être vide")
+        payload = KaliContConsultRequest(id=kali_id.strip()).model_dump(
+            by_alias=True, exclude_none=True
+        )
+        response = self._client.call_api("consult/kaliCont", payload)
+        return self._wrap_container(response.json())
+
+    def fetch_by_idcc(self, idcc: str | int) -> ConventionCollective | None:
+        """Récupère un conteneur par son numéro IDCC.
+
+        Wraps ``POST /consult/kaliContIdcc``. ``idcc`` doit être un
+        entier ou une chaîne de chiffres (ex: ``"1261"``).
+        """
+        idcc_str = str(idcc).strip()
+        if not _IDCC_PATTERN.match(idcc_str):
+            raise ValueError(
+                f"IDCC invalide: {idcc!r}. Attendu: 1 à 5 chiffres (ex: '1261')."
+            )
+        payload = KaliContConsultIdccRequest(id=idcc_str).model_dump(by_alias=True)
+        response = self._client.call_api("consult/kaliContIdcc", payload)
+        return self._wrap_container(response.json())
+
+    def fetch_text(self, kali_id: str) -> TexteKali | None:
+        """Récupère un texte KALI par son identifiant ``KALITEXT``.
+
+        Wraps ``POST /consult/kaliText``.
+        """
+        if not kali_id or not kali_id.strip():
+            raise ValueError("kali_id ne peut pas être vide")
+        payload = KaliTextConsultRequest(id=kali_id.strip()).model_dump(
+            by_alias=True, exclude_none=True
+        )
+        response = self._client.call_api("consult/kaliText", payload)
+        return self._wrap_text(response.json())
+
+    def fetch_article(self, article_id: str) -> TexteKali | None:
+        """Récupère le texte parent contenant un article ``KALIARTI``.
+
+        Wraps ``POST /consult/kaliArticle``. Le endpoint retourne le
+        texte entier contextualisé autour de l'article demandé.
+        """
+        if not article_id or not article_id.strip():
+            raise ValueError("article_id ne peut pas être vide")
+        payload = KaliTextConsultArticleRequest(id=article_id.strip()).model_dump(
+            by_alias=True
+        )
+        response = self._client.call_api("consult/kaliArticle", payload)
+        return self._wrap_text(response.json())
+
+    def fetch_section(self, section_id: str) -> TexteKali | None:
+        """Récupère le texte parent contenant une section ``KALISCTA``.
+
+        Wraps ``POST /consult/kaliSection``.
+        """
+        if not section_id or not section_id.strip():
+            raise ValueError("section_id ne peut pas être vide")
+        payload = KaliTextConsultSectionRequest(id=section_id.strip()).model_dump(
+            by_alias=True
+        )
+        response = self._client.call_api("consult/kaliSection", payload)
+        return self._wrap_text(response.json())
+
+    def fetch(self, kali_id: str) -> ConventionCollective | TexteKali | None:
+        """Dispatcher basé sur le préfixe de l'identifiant.
+
+        - ``KALICONT`` → :meth:`fetch_container`
+        - ``KALITEXT`` → :meth:`fetch_text`
+        - ``KALIARTI`` → :meth:`fetch_article`
+        - ``KALISCTA`` → :meth:`fetch_section`
+        """
+        if not kali_id or not kali_id.strip():
+            raise ValueError("kali_id ne peut pas être vide")
+        normalized = kali_id.strip()
+        if normalized.startswith(KALI_CONT_PREFIX):
+            return self.fetch_container(normalized)
+        if normalized.startswith(KALI_TEXT_PREFIX):
+            return self.fetch_text(normalized)
+        if normalized.startswith(KALI_ARTI_PREFIX):
+            return self.fetch_article(normalized)
+        if normalized.startswith(KALI_SCTA_PREFIX):
+            return self.fetch_section(normalized)
+        raise ValueError(
+            f"Préfixe KALI inconnu dans {kali_id!r}. "
+            f"Attendu un des: {', '.join(KALI_PREFIXES)}."
+        )
+
+    def search(self, query: str | SearchRequest) -> list[ConventionCollective]:
+        """Recherche dans le fond KALI.
+
+        La recherche renvoie des conteneurs (``KALICONT...``) : pour
+        chaque résultat le ``id`` du premier titre est extrait puis
+        hydraté via :meth:`fetch_container`, afin d'exposer uniformément
+        des :class:`ConventionCollective`.
+
+        Args:
+            query: texte libre ou :class:`SearchRequest` pré-construit.
+
+        Returns:
+            Liste de :class:`ConventionCollective`. Vide si aucun
+            résultat.
+        """
+        if isinstance(query, str):
+            search_query = SearchRequest(search=query)
+        else:
+            search_query = query
+
+        request_dto = search_query.to_api_model()
+        payload = json.loads(
+            json.dumps(request_dto.model_dump(by_alias=True), cls=EnumEncoder)
+        )
+        response = self._client.call_api("search", payload)
+
+        if response.status_code != HTTP_OK:
+            return []
+
+        response_data = response.json()
+        raw_results = response_data.get("results")
+        if not isinstance(raw_results, list):
+            return []
+
+        containers: list[ConventionCollective] = []
+        for result in raw_results:
+            text_id = self._extract_result_id(result)
+            if text_id is None:
+                continue
+            try:
+                container = self.fetch_container(text_id)
+            except Exception as exc:
+                logger.warning(
+                    "Échec de récupération du conteneur KALI %s: %s", text_id, exc
+                )
+                continue
+            if container is not None:
+                containers.append(container)
+        return containers
+
+    @staticmethod
+    def _extract_result_id(result: dict[str, Any]) -> str | None:
+        titles = result.get("titles")
+        if not isinstance(titles, list) or not titles:
+            return None
+        first = titles[0]
+        if not isinstance(first, dict):
+            return None
+        text_id = first.get("id")
+        return text_id if isinstance(text_id, str) and text_id else None
+
+    def _wrap_container(
+        self, response_data: dict[str, Any] | None
+    ) -> ConventionCollective | None:
+        if not response_data:
+            return None
+        try:
+            model = ConsultKaliContResponse.model_validate(response_data)
+        except Exception as exc:
+            logger.error("Échec de validation ConsultKaliContResponse: %s", exc)
+            return None
+        return ConventionCollective(model, self._client)
+
+    def _wrap_text(self, response_data: dict[str, Any] | None) -> TexteKali | None:
+        if not response_data:
+            return None
+        try:
+            model = ConsultKaliTextResponse.model_validate(response_data)
+        except Exception as exc:
+            logger.error("Échec de validation ConsultKaliTextResponse: %s", exc)
+            return None
+        return TexteKali(model, self._client)

--- a/pylegifrance/models/kali/__init__.py
+++ b/pylegifrance/models/kali/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models for the KALI fond (French collective bargaining agreements)."""

--- a/pylegifrance/models/kali/enum.py
+++ b/pylegifrance/models/kali/enum.py
@@ -1,0 +1,42 @@
+from enum import StrEnum
+
+
+class TypeChampKali(StrEnum):
+    """Champs de recherche disponibles pour le fond KALI.
+
+    Restreint à la liste documentée dans
+    ``docs/raw/legifrance/description-des-tris-et-filtres-de-l-api.md``
+    (section KALI). ``TypeChamp`` généré contient d'autres valeurs valides
+    pour d'autres fonds mais non acceptées par la recherche KALI.
+    """
+
+    ALL = "ALL"
+    TITLE = "TITLE"
+    IDCC = "IDCC"
+    MOTS_CLES = "MOTS_CLES"
+    ARTICLE = "ARTICLE"
+
+
+class SortKali(StrEnum):
+    """Options de tri pour les recherches dans le fond KALI."""
+
+    PERTINENCE = "PERTINENCE"
+    SIGNATURE_DATE_DESC = "SIGNATURE_DATE_DESC"
+    SIGNATURE_DATE_ASC = "SIGNATURE_DATE_ASC"
+    MODIFICATION_DATE_DESC = "MODIFICATION_DATE_DESC"
+
+
+class FacettesKALI(StrEnum):
+    """Facettes de filtrage documentées pour le fond KALI.
+
+    Sous-ensemble minimal couvrant les usages courants (état juridique,
+    IDCC, plages de dates). Les autres facettes documentées
+    (``ACTIVITE``, ``NUM_TEXTE_CITE``...) peuvent être ajoutées à la
+    demande.
+    """
+
+    LEGAL_STATUS = "LEGAL_STATUS"
+    ARTICLE_LEGAL_STATUS = "ARTICLE_LEGAL_STATUS"
+    IDCC = "IDCC"
+    DATE_SIGNATURE = "DATE_SIGNATURE"
+    DATE_PUBLICATION = "DATE_PUBLICATION"

--- a/pylegifrance/models/kali/search.py
+++ b/pylegifrance/models/kali/search.py
@@ -1,0 +1,144 @@
+"""Search request model for the KALI fond."""
+
+from datetime import datetime
+
+from pydantic import Field, ValidationInfo, field_validator
+
+from pylegifrance.models.base import PyLegifranceBaseModel
+from pylegifrance.models.generated.model import (
+    ChampDTO,
+    CritereDTO,
+    DatePeriod,
+    FiltreDTO,
+    Fond,
+    Operateur,
+    RechercheSpecifiqueDTO,
+    SearchRequestDTO,
+    TypeChamp,
+    TypePagination,
+    TypeRecherche,
+)
+from pylegifrance.models.kali.enum import FacettesKALI, SortKali, TypeChampKali
+
+EN_VIGUEUR_STATUSES: list[str] = [
+    "VIGUEUR",
+    "VIGUEUR_ETEN",
+    "VIGUEUR_NON_ETEN",
+]
+
+
+class SearchRequest(PyLegifranceBaseModel):
+    """Requête de recherche dans le fond KALI (conventions collectives)."""
+
+    search: str = Field("", description="Texte ou mots-clés à rechercher")
+    field: TypeChampKali = Field(default=TypeChampKali.ALL)
+    search_type: TypeRecherche = Field(
+        default=TypeRecherche.tous_les_mots_dans_un_champ
+    )
+    sort: SortKali = Field(default=SortKali.PERTINENCE)
+    page_size: int = Field(default=10, ge=1, le=100)
+    page_number: int = Field(default=1, ge=1)
+
+    idcc: str | None = Field(
+        default=None,
+        description="Filtre par numéro IDCC (ex: '1261').",
+    )
+    legal_status: list[str] | None = Field(
+        default_factory=lambda: list(EN_VIGUEUR_STATUSES),
+        description=(
+            "Filtre par état juridique du texte. Par défaut restreint aux "
+            "conventions 'en vigueur' (VIGUEUR, VIGUEUR_ETEN, "
+            "VIGUEUR_NON_ETEN). Passer une liste vide ou ``None`` pour "
+            "désactiver le filtre."
+        ),
+    )
+    date_signature_start: str | None = Field(
+        default=None, description="Début de plage — date de signature (YYYY-MM-DD)."
+    )
+    date_signature_end: str | None = Field(
+        default=None, description="Fin de plage — date de signature (YYYY-MM-DD)."
+    )
+
+    @field_validator("date_signature_start", "date_signature_end")
+    @classmethod
+    def validate_date_format(cls, v: str | None) -> str | None:
+        if v is not None:
+            try:
+                datetime.fromisoformat(v)
+            except ValueError:
+                raise ValueError(
+                    f"Date must be in ISO format (YYYY-MM-DD), got: {v}"
+                ) from None
+        return v
+
+    @field_validator("date_signature_end")
+    @classmethod
+    def validate_date_range(cls, v: str | None, info: ValidationInfo) -> str | None:
+        start = info.data.get("date_signature_start")
+        if v is not None and start is not None:
+            if datetime.fromisoformat(v) < datetime.fromisoformat(start):
+                raise ValueError("date_signature_end must be >= date_signature_start")
+        return v
+
+    def to_api_model(self) -> SearchRequestDTO:
+        """Convert to the generated API DTO."""
+        criteria = CritereDTO(
+            valeur=self.search,
+            operateur=Operateur.et,
+            typeRecherche=self.search_type,
+            proximite=None,
+            criteres=None,
+        )
+        champ = ChampDTO(
+            criteres=[criteria],
+            operateur=Operateur.et,
+            typeChamp=TypeChamp(self.field.value),
+        )
+
+        filtres: list[FiltreDTO] = []
+        if self.idcc is not None:
+            filtres.append(
+                FiltreDTO(
+                    facette=FacettesKALI.IDCC.value,
+                    valeurs=[self.idcc],
+                    dates=None,
+                    singleDate=None,
+                    multiValeurs=None,
+                )
+            )
+        if self.legal_status:
+            filtres.append(
+                FiltreDTO(
+                    facette=FacettesKALI.LEGAL_STATUS.value,
+                    valeurs=self.legal_status,
+                    dates=None,
+                    singleDate=None,
+                    multiValeurs=None,
+                )
+            )
+        if self.date_signature_start and self.date_signature_end:
+            filtres.append(
+                FiltreDTO(
+                    facette=FacettesKALI.DATE_SIGNATURE.value,
+                    valeurs=None,
+                    dates=DatePeriod(
+                        start=datetime.fromisoformat(self.date_signature_start),
+                        end=datetime.fromisoformat(self.date_signature_end),
+                    ),
+                    singleDate=None,
+                    multiValeurs=None,
+                )
+            )
+
+        recherche = RechercheSpecifiqueDTO(
+            champs=[champ],
+            filtres=filtres,
+            pageNumber=self.page_number,
+            pageSize=self.page_size,
+            sort=self.sort.value,
+            fromAdvancedRecherche=False,
+            secondSort="ID",
+            typePagination=TypePagination.defaut,
+            operateur=Operateur.et,
+        )
+        return SearchRequestDTO(recherche=recherche, fond=Fond.kali)

--- a/tests/integration/fonds/kali/test_kali_live.py
+++ b/tests/integration/fonds/kali/test_kali_live.py
@@ -1,0 +1,45 @@
+"""Live integration test for the KALI façade.
+
+Hits the real Legifrance API and therefore requires valid credentials
+via the ``api_client`` fixture (``tests/conftest.py`` — reads
+``LEGIFRANCE_CLIENT_ID`` / ``LEGIFRANCE_CLIENT_SECRET`` from the
+environment).
+
+Uses IDCC ``1261`` (« Acteurs du lien social et familial ») because it
+is the example cited in the DILA-generated schema
+(``KaliContConsultIdccRequest.examples = ["1261"]``,
+``ConsultKaliContResponse.id examples = ["KALICONT000005635384"]``).
+"""
+
+import pytest
+
+from pylegifrance.fonds.kali import ConventionCollective, KaliAPI
+
+LEGIFRANCE_KALI_BASE = "https://www.legifrance.gouv.fr/conv_coll/id/"
+
+
+@pytest.fixture(scope="module")
+def kali_api(api_client) -> KaliAPI:
+    return KaliAPI(api_client)
+
+
+def test_fetch_by_idcc_1261_returns_real_convention(kali_api: KaliAPI) -> None:
+    """Fetch IDCC 1261 live and surface a browseable legifrance.gouv.fr URL.
+
+    Run with ``pytest -s`` to see the URL printed to stdout. The URL is
+    also embedded in the assertion message so it appears on failure
+    too.
+    """
+    convention = kali_api.fetch_by_idcc("1261")
+
+    assert convention is not None, "IDCC 1261 doit résoudre sur l'API live"
+    assert isinstance(convention, ConventionCollective)
+    assert convention.id is not None and convention.id.startswith("KALICONT")
+    assert convention.idcc == "1261"
+
+    url = f"{LEGIFRANCE_KALI_BASE}{convention.id}"
+    print(f"\n  IDCC 1261 → {convention.titre!r}\n  URL: {url}\n")
+
+    assert url.startswith("https://www.legifrance.gouv.fr/conv_coll/id/KALICONT"), (
+        f"URL attendue au format /conv_coll/id/KALICONT..., obtenue: {url}"
+    )

--- a/tests/unit/fonds/test_kali.py
+++ b/tests/unit/fonds/test_kali.py
@@ -1,0 +1,257 @@
+"""Unit tests for the KALI façade.
+
+These tests target the ``pylegifrance.fonds.kali`` module at the
+:meth:`LegifranceClient.call_api` boundary, mirroring the style of
+``tests/unit/fonds/test_juri_verification_endpoints.py``. No live HTTP.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pylegifrance.fonds.kali import (
+    ConventionCollective,
+    KaliAPI,
+    TexteKali,
+)
+from pylegifrance.models.kali.enum import FacettesKALI, SortKali, TypeChampKali
+from pylegifrance.models.kali.search import SearchRequest
+
+
+def _mock_response(status_code: int, payload):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+def _cont_payload(cont_id: str = "KALICONT000005635384") -> dict:
+    return {
+        "id": cont_id,
+        "titre": "Convention collective nationale du secteur exemple",
+        "num": "1261",
+        "numeroTexte": "IDCC 1261",
+        "nature": "IDCC",
+        "texteBaseId": ["KALITEXT000005677408"],
+        "sections": [],
+    }
+
+
+def _text_payload() -> dict:
+    return {
+        "title": "Avenant du 12 janvier 2020",
+        "etat": "VIGUEUR_ETEN",
+        "typeTexte": "TEXTE_BASE",
+        "idConteneur": "KALICONT000005635384",
+        "nor": "ABCD1234567X",
+        "articles": [],
+    }
+
+
+def _search_payload(ids: list[str]) -> dict:
+    return {
+        "totalNbResult": len(ids),
+        "executionTime": 3,
+        "pageNumber": 1,
+        "pageSize": 10,
+        "results": [{"titles": [{"id": kid}]} for kid in ids],
+    }
+
+
+class TestFetchContainer:
+    def test_wraps_response_as_convention_collective(self):
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(200, _cont_payload())
+
+        result = KaliAPI(client).fetch_container("KALICONT000005635384")
+
+        assert isinstance(result, ConventionCollective)
+        assert result.id == "KALICONT000005635384"
+        assert result.idcc == "1261"
+        assert result.numero_texte == "IDCC 1261"
+        route, payload = client.call_api.call_args.args
+        assert route == "consult/kaliCont"
+        assert payload == {"id": "KALICONT000005635384"}
+
+    def test_rejects_empty_id(self):
+        with pytest.raises(ValueError):
+            KaliAPI(MagicMock()).fetch_container("")
+
+
+class TestFetchByIdcc:
+    def test_calls_idcc_endpoint_with_normalized_id(self):
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(200, _cont_payload())
+
+        KaliAPI(client).fetch_by_idcc(1261)
+
+        route, payload = client.call_api.call_args.args
+        assert route == "consult/kaliContIdcc"
+        assert payload == {"id": "1261"}
+
+    def test_rejects_non_numeric_idcc(self):
+        with pytest.raises(ValueError):
+            KaliAPI(MagicMock()).fetch_by_idcc("IDCC-1261")
+
+
+class TestFetchText:
+    def test_wraps_response_as_texte_kali(self):
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(200, _text_payload())
+
+        result = KaliAPI(client).fetch_text("KALITEXT000005677408")
+
+        assert isinstance(result, TexteKali)
+        assert result.titre == "Avenant du 12 janvier 2020"
+        assert result.etat == "VIGUEUR_ETEN"
+        assert result.container_id == "KALICONT000005635384"
+        route, payload = client.call_api.call_args.args
+        assert route == "consult/kaliText"
+        assert payload == {"id": "KALITEXT000005677408"}
+
+
+class TestFetchDispatcher:
+    @pytest.mark.parametrize(
+        ("kali_id", "expected_route"),
+        [
+            ("KALICONT000005635384", "consult/kaliCont"),
+            ("KALITEXT000005677408", "consult/kaliText"),
+            ("KALIARTI000005833238", "consult/kaliArticle"),
+            ("KALISCTA000005716465", "consult/kaliSection"),
+        ],
+    )
+    def test_routes_by_prefix(self, kali_id, expected_route):
+        client = MagicMock()
+        payload = _cont_payload() if kali_id.startswith("KALICONT") else _text_payload()
+        client.call_api.return_value = _mock_response(200, payload)
+
+        KaliAPI(client).fetch(kali_id)
+
+        route, _ = client.call_api.call_args.args
+        assert route == expected_route
+
+    def test_rejects_unknown_prefix(self):
+        with pytest.raises(ValueError):
+            KaliAPI(MagicMock()).fetch("LEGITEXT000005677408")
+
+
+class TestSearch:
+    def test_hydrates_results_to_containers(self):
+        client = MagicMock()
+        client.call_api.side_effect = [
+            _mock_response(200, _search_payload(["KALICONT000005635384"])),
+            _mock_response(200, _cont_payload("KALICONT000005635384")),
+        ]
+
+        results = KaliAPI(client).search("santé prévoyance")
+
+        assert len(results) == 1
+        assert isinstance(results[0], ConventionCollective)
+        assert results[0].id == "KALICONT000005635384"
+        assert client.call_api.call_count == 2
+
+    def test_returns_empty_list_on_non_200(self):
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(500, {})
+
+        assert KaliAPI(client).search("x") == []
+
+    def test_accepts_prebuilt_search_request(self):
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(200, _search_payload([]))
+
+        req = SearchRequest(
+            search="2098",
+            field=TypeChampKali.IDCC,
+            idcc="2098",
+            sort=SortKali.SIGNATURE_DATE_DESC,
+        )
+        KaliAPI(client).search(req)
+
+        payload = client.call_api.call_args.args[1]
+        assert payload["fond"] == "KALI"
+        recherche = payload["recherche"]
+        assert recherche["pageSize"] == 10
+        assert recherche["sort"] == "SIGNATURE_DATE_DESC"
+        assert recherche["champs"][0]["typeChamp"] == "IDCC"
+        assert any(
+            f.get("facette") == FacettesKALI.IDCC.value and f.get("valeurs") == ["2098"]
+            for f in recherche["filtres"]
+        )
+
+
+class TestSearchRequestToApiModel:
+    def test_default_emits_fond_kali_with_all_field(self):
+        dto = SearchRequest(search="salaire").to_api_model()
+
+        assert dto.fond.value == "KALI"
+        champs = dto.recherche.champs
+        assert champs is not None and len(champs) == 1
+        type_champ = champs[0].type_champ
+        assert type_champ is not None and type_champ.value == "ALL"
+        criteres = champs[0].criteres
+        assert criteres is not None and criteres[0].valeur == "salaire"
+
+    def test_default_applies_en_vigueur_filter(self):
+        """Par défaut, la recherche KALI filtre aux conventions en vigueur."""
+        dto = SearchRequest(search="salaire").to_api_model()
+        filtres = dto.recherche.filtres
+        assert filtres is not None
+        legal_filters = [
+            f for f in filtres if f.facette == FacettesKALI.LEGAL_STATUS.value
+        ]
+        assert len(legal_filters) == 1
+        assert legal_filters[0].valeurs == [
+            "VIGUEUR",
+            "VIGUEUR_ETEN",
+            "VIGUEUR_NON_ETEN",
+        ]
+
+    def test_legal_status_filter_is_materialized(self):
+        req = SearchRequest(search="", legal_status=["VIGUEUR_ETEN"])
+        dto = req.to_api_model()
+        filtres = dto.recherche.filtres
+        assert filtres is not None
+        assert any(
+            f.facette == FacettesKALI.LEGAL_STATUS.value
+            and f.valeurs == ["VIGUEUR_ETEN"]
+            for f in filtres
+        )
+
+    def test_legal_status_none_disables_filter(self):
+        """``legal_status=None`` désactive le filtre par défaut."""
+        dto = SearchRequest(search="", legal_status=None).to_api_model()
+        filtres = dto.recherche.filtres or []
+        assert not any(f.facette == FacettesKALI.LEGAL_STATUS.value for f in filtres)
+
+    def test_legal_status_empty_list_disables_filter(self):
+        """``legal_status=[]`` désactive également le filtre par défaut."""
+        dto = SearchRequest(search="", legal_status=[]).to_api_model()
+        filtres = dto.recherche.filtres or []
+        assert not any(f.facette == FacettesKALI.LEGAL_STATUS.value for f in filtres)
+
+    def test_invalid_date_range_rejected(self):
+        with pytest.raises(ValueError):
+            SearchRequest(
+                search="",
+                date_signature_start="2020-01-01",
+                date_signature_end="2019-01-01",
+            )
+
+
+class TestConventionCollectiveMarkdown:
+    def test_to_markdown_includes_core_metadata(self):
+        cc = ConventionCollective(
+            data=_cont_payload_model(),
+            client=MagicMock(),
+        )
+        md = cc.to_markdown()
+        assert "IDCC" in md
+        assert "1261" in md
+        assert "KALICONT000005635384" in md
+
+
+def _cont_payload_model():
+    from pylegifrance.models.generated.model import ConsultKaliContResponse
+
+    return ConsultKaliContResponse.model_validate(_cont_payload())


### PR DESCRIPTION
## Summary

- Nouvelle façade `pylegifrance/fonds/kali.py` : `KaliAPI` (fetch_container, fetch_by_idcc, fetch_text, fetch_article, fetch_section, dispatcher `fetch`, `search`) plus les wrappers de domaine `ConventionCollective` / `TexteKali`.
- Modèles de recherche sous `pylegifrance/models/kali/` : `TypeChampKali`, `SortKali`, `FacettesKALI`, `SearchRequest` → `SearchRequestDTO(fond=Fond.kali)`.
- Défaut `legal_status = ["VIGUEUR", "VIGUEUR_ETEN", "VIGUEUR_NON_ETEN"]` : la recherche retourne uniquement les conventions en vigueur, overridable via `None` ou `[]`.
- 20 tests unitaires + 1 test d'intégration live contre l'API PISTE (IDCC 1261 → `KALICONT000005635384`, URL canonique `https://www.legifrance.gouv.fr/conv_coll/id/…` vérifiée).
- Wiki : `entities/fond-kali.md` + carte au catalogue + entrée `docs/log.md`.

Pas d'endpoint `versions` / `version/at` côté DILA pour KALI, donc pas de `.at(date)` / `.versions()` (contrairement à LODA).

## Test plan

- [x] `uv run pytest tests/unit` — 123/123 passent
- [x] `uv run pytest tests/integration/fonds/kali/test_kali_live.py -s` — live PISTE OK, URL surfacée
- [x] `uvx ruff check` — propre
- [x] `uvx ruff format --check` — propre
- [x] `uvx ty check` — propre

🤖 Generated with [Claude Code](https://claude.com/claude-code)