### PR TITLE
ci(release): add workflow_dispatch to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
     tags: ["v*", "pylegifrance-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v1.6.0). Required when dispatched manually."
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -39,7 +45,10 @@ jobs:
             --manifest-file=.github/release-please-manifest.json
 
   publish:
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/pylegifrance-v')
+    if: >-
+      startsWith(github.ref, 'refs/tags/v')
+      || startsWith(github.ref, 'refs/tags/pylegifrance-v')
+      || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     permissions:
       contents: read
@@ -49,6 +58,8 @@ jobs:
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Common Environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

- Ajoute un trigger \`workflow_dispatch\` avec input \`tag\` au workflow Release, pour pouvoir déclencher manuellement la publication PyPI sur un tag existant.
- Débloque la situation où release-please crée un tag avec \`GITHUB_TOKEN\` : GitHub n'enchaîne alors pas le workflow \`on: push: tags:\`, donc le job \`publish\` reste skipped et PyPI n'est jamais mis à jour. C'est ce qui s'est passé pour v1.5.1 et v1.6.0.
- Étend la condition \`if:\` du job \`publish\` pour accepter \`workflow_dispatch\`, et le checkout prend le tag passé en input.

## Test plan

- [x] PR passe la CI \`test\`
- [ ] Après merge, dispatch manuellement sur \`v1.6.0\` et confirmer que 1.6.0 apparaît sur https://pypi.org/project/pylegifrance/

🤖 Generated with [Claude Code](https://claude.com/claude-code)