### PR TITLE
ci(release): use dispatch-input tag for version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,11 @@ jobs:
           create-env-file: "false"
 
       - name: Check tag vs pyproject version
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#pylegifrance-v}"
+          TAG_REF="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG_REF#pylegifrance-v}"
           TAG_VERSION="${TAG_VERSION#v}"
           PROJECT_VERSION=$(awk -F\" '/^version =/ {print $2}' pyproject.toml)
           if [ "$TAG_VERSION" != "$PROJECT_VERSION" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #57. Le job \`publish\` dispatché manuellement checkait \`GITHUB_REF_NAME\` (= \`main\` quand dispatché sur main) au lieu du tag input. Résultat : \`Tag version (main) does not match pyproject.toml version (1.6.0)\`.

Correction : lire le tag depuis l'input \`workflow_dispatch\` d'abord, fallback sur \`GITHUB_REF_NAME\` pour les push-tag events.

## Test plan

- [x] CI verte
- [ ] Après merge, dispatch sur tag=v1.6.0 et vérifier 1.6.0 sur PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)