### PR TITLE
fix(kali): return TexteKali from search (API returns texts, not containers)

### DIFF
--- a/pylegifrance/fonds/kali.py
+++ b/pylegifrance/fonds/kali.py
@@ -329,20 +329,24 @@ class KaliAPI:
             f"Attendu un des: {', '.join(KALI_PREFIXES)}."
         )
 
-    def search(self, query: str | SearchRequest) -> list[ConventionCollective]:
+    def search(self, query: str | SearchRequest) -> list[TexteKali]:
         """Recherche dans le fond KALI.
 
-        La recherche renvoie des conteneurs (``KALICONT...``) : pour
-        chaque résultat le ``id`` du premier titre est extrait puis
-        hydraté via :meth:`fetch_container`, afin d'exposer uniformément
-        des :class:`ConventionCollective`.
+        Le endpoint ``/search`` du fond KALI retourne des **textes**
+        (accords, avenants, etc.), pas des conteneurs : pour chaque
+        résultat le ``id`` du premier titre est un ``KALITEXT...`` que
+        l'on hydrate via :meth:`fetch_text`, afin d'exposer
+        uniformément des :class:`TexteKali`.
+
+        Pour obtenir la convention collective (conteneur) associée,
+        utiliser :meth:`fetch_by_idcc` ou :meth:`fetch_container` à
+        partir d'un identifiant ``KALICONT`` connu.
 
         Args:
             query: texte libre ou :class:`SearchRequest` pré-construit.
 
         Returns:
-            Liste de :class:`ConventionCollective`. Vide si aucun
-            résultat.
+            Liste de :class:`TexteKali`. Vide si aucun résultat.
         """
         if isinstance(query, str):
             search_query = SearchRequest(search=query)
@@ -363,21 +367,21 @@ class KaliAPI:
         if not isinstance(raw_results, list):
             return []
 
-        containers: list[ConventionCollective] = []
+        texts: list[TexteKali] = []
         for result in raw_results:
             text_id = self._extract_result_id(result)
             if text_id is None:
                 continue
             try:
-                container = self.fetch_container(text_id)
+                text = self.fetch_text(text_id)
             except Exception as exc:
                 logger.warning(
-                    "Échec de récupération du conteneur KALI %s: %s", text_id, exc
+                    "Échec de récupération du texte KALI %s: %s", text_id, exc
                 )
                 continue
-            if container is not None:
-                containers.append(container)
-        return containers
+            if text is not None:
+                texts.append(text)
+        return texts
 
     @staticmethod
     def _extract_result_id(result: dict[str, Any]) -> str | None:

--- a/tests/unit/fonds/test_kali.py
+++ b/tests/unit/fonds/test_kali.py
@@ -136,19 +136,28 @@ class TestFetchDispatcher:
 
 
 class TestSearch:
-    def test_hydrates_results_to_containers(self):
+    def test_hydrates_results_to_texts(self):
+        """The KALI /search endpoint returns KALITEXT ids in each
+        ``results[i].titles[0].id``. Each result is hydrated via
+        ``fetch_text`` so the return type is ``list[TexteKali]``.
+        """
         client = MagicMock()
         client.call_api.side_effect = [
-            _mock_response(200, _search_payload(["KALICONT000005635384"])),
-            _mock_response(200, _cont_payload("KALICONT000005635384")),
+            _mock_response(200, _search_payload(["KALITEXT000005677408"])),
+            _mock_response(200, _text_payload()),
         ]
 
         results = KaliAPI(client).search("santé prévoyance")
 
         assert len(results) == 1
-        assert isinstance(results[0], ConventionCollective)
-        assert results[0].id == "KALICONT000005635384"
+        assert isinstance(results[0], TexteKali)
         assert client.call_api.call_count == 2
+        # Second call must hit the kaliText endpoint, not kaliCont —
+        # this is the regression guard for the 1.6.0 bug where a
+        # KALITEXT id was passed to ``consult/kaliCont``, triggering
+        # empty-body JSON decode failures.
+        second_route = client.call_api.call_args_list[1].args[0]
+        assert second_route == "consult/kaliText"
 
     def test_returns_empty_list_on_non_200(self):
         client = MagicMock()


### PR DESCRIPTION
## Summary

The `KaliAPI.search()` method introduced in 1.6.0 currently returns `[]` against the live Legifrance API for every query. Root cause: the `/search` endpoint for fond KALI returns **texts** (`KALITEXT...` ids) in `results[i].titles[0].id`, but `search()` pipes those ids into `fetch_container()` → `POST /consult/kaliCont`, an endpoint that only accepts `KALICONT...` ids. Legifrance responds with an empty body; `response.json()` raises `json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`; the outer `try/except` catches it and warning-logs every result, leaving the final list empty.

## Reproduction (against the live API, 1.6.0)

```python
from pylegifrance import ApiConfig, LegifranceClient
from pylegifrance.fonds.kali import KaliAPI

client = LegifranceClient(config=ApiConfig.from_env())
print(KaliAPI(client).search(\"SYNTEC\"))  # => []
```

Stderr (one warning per discarded result):
```
Échec de récupération du conteneur KALI KALITEXT000022968985: Expecting value: line 1 column 1 (char 0)
Échec de récupération du conteneur KALI KALITEXT000005679954: Expecting value: line 1 column 1 (char 0)
...
```

## Why the unit test missed this

The existing `test_hydrates_results_to_containers` mocks the search response with a `KALICONT` id:
```python
_mock_response(200, _search_payload([\"KALICONT000005635384\"])),
```
which does not match what the real API returns (`KALITEXT...`). So the mock-vs-reality divergence shipped as a release.

A raw live search response shows zero `KALICONT` references anywhere in the payload — `titles[0].id` is always `KALITEXT`, `idcc` is always `null`, and there is no nested container id to recover. A search result cannot be hydrated into a `ConventionCollective` without additional round-trips that have no reliable starting point.

## Fix

* **Hydrate with `fetch_text` instead of `fetch_container`.** `fetch_text` calls `POST /consult/kaliText`, which accepts `KALITEXT` ids — exactly what `/search` returns.
* **Change the return type annotation from `list[ConventionCollective]` to `list[TexteKali]`** to reflect what the KALI `/search` endpoint actually returns.
* Update the docstring to document this and point callers to `fetch_by_idcc(idcc)` or `fetch_container(kalicont_id)` when they need the parent convention collective (container).
* Update the unit test mock to use a realistic `KALITEXT` id and assert the hydration route is `consult/kaliText` — a regression guard against dropping back to `consult/kaliCont`.

## Verification

- All 123 unit tests pass (`uv run pytest tests/unit`).
- `ruff check`, `ruff format --check`, `uvx ty check` all clean.
- **Live API**: `KaliAPI(client).search(\"SYNTEC\")` now returns **10** `TexteKali` results fully hydrated with titles, signataires, articles, etc. (Pre-fix: `[]` on the same query.)

## Breaking change notice

This changes the return type of `KaliAPI.search()` from `list[ConventionCollective]` to `list[TexteKali]`. Strictly a semver-major change, but in practice the pre-fix behaviour returned `[]` on all real-API inputs, so the only callers who could be relying on the old signature are those already broken. 1.6.0 is 2 days old at the time of this PR.

## Test plan

- [x] Unit tests: new regression asserts `consult/kaliText` endpoint
- [x] Lint / format / type check clean
- [x] Verified live that `search(\"SYNTEC\")`, `search(\"hotellerie\")`, `search(\"metallurgie\")` all return non-empty `list[TexteKali]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)