### PR TITLE
fix(kali): dispatch search hits by id prefix and navigate to enclosing container

### DIFF
--- a/pylegifrance/fonds/kali.py
+++ b/pylegifrance/fonds/kali.py
@@ -332,17 +332,32 @@ class KaliAPI:
     def search(self, query: str | SearchRequest) -> list[ConventionCollective]:
         """Recherche dans le fond KALI.
 
-        La recherche renvoie des conteneurs (``KALICONT...``) : pour
-        chaque résultat le ``id`` du premier titre est extrait puis
-        hydraté via :meth:`fetch_container`, afin d'exposer uniformément
-        des :class:`ConventionCollective`.
+        Le endpoint ``/search`` peut renvoyer différents types
+        d'identifiants — typiquement des ``KALITEXT...`` (texte : une
+        convention spécifique, un avenant…), parfois des
+        ``KALICONT...`` (conteneur : la convention collective
+        parente). Chaque identifiant est dispatché par préfixe via
+        :meth:`fetch` pour charger l'entité correcte, puis ramené à un
+        :class:`ConventionCollective` (conteneur) : pour un hit texte,
+        on navigue vers le conteneur parent via
+        :attr:`TexteKali.container_id`.
 
         Args:
             query: texte libre ou :class:`SearchRequest` pré-construit.
 
         Returns:
-            Liste de :class:`ConventionCollective`. Vide si aucun
-            résultat.
+            Liste de :class:`ConventionCollective` déduplicée par
+            identifiant conteneur. Vide si aucun résultat n'a pu être
+            résolu vers un conteneur.
+
+        Note:
+            Limitation connue — un hit ``KALITEXT...`` dont la charge
+            utile ne contient pas ``idConteneur`` est ignoré silen-
+            cieusement (il n'y a pas d'autre chemin pour remonter au
+            conteneur parent sans API additionnelle). Les avenants
+            isolés peuvent donc être absents des résultats même après
+            ce correctif ; une résolution complète nécessiterait un
+            complément côté API Legifrance.
         """
         if isinstance(query, str):
             search_query = SearchRequest(search=query)
@@ -364,17 +379,48 @@ class KaliAPI:
             return []
 
         containers: list[ConventionCollective] = []
+        seen_container_ids: set[str] = set()
         for result in raw_results:
-            text_id = self._extract_result_id(result)
-            if text_id is None:
+            result_id = self._extract_result_id(result)
+            if result_id is None:
                 continue
             try:
-                container = self.fetch_container(text_id)
+                entity = self.fetch(result_id)
             except Exception as exc:
-                logger.warning(
-                    "Échec de récupération du conteneur KALI %s: %s", text_id, exc
-                )
+                logger.warning("Échec de récupération KALI %s: %s", result_id, exc)
                 continue
+            if entity is None:
+                continue
+
+            container: ConventionCollective | None
+            if isinstance(entity, ConventionCollective):
+                cont_id = entity.id
+                if not cont_id or cont_id in seen_container_ids:
+                    continue
+                seen_container_ids.add(cont_id)
+                container = entity
+            elif isinstance(entity, TexteKali):
+                parent_id = entity.container_id
+                # Dedupe BEFORE issuing the /consult/kaliCont call so
+                # N text hits under the same convention cost 1 extra
+                # fetch, not N.
+                if not parent_id or parent_id in seen_container_ids:
+                    continue
+                seen_container_ids.add(parent_id)
+                try:
+                    container = self.fetch_container(parent_id)
+                except Exception as exc:
+                    logger.warning(
+                        "Échec de récupération du conteneur KALI %s: %s",
+                        parent_id,
+                        exc,
+                    )
+                    continue
+            else:
+                # KALIARTI / KALISCTA hits are not search-level
+                # convention sources — skip.
+                continue
+
             if container is not None:
                 containers.append(container)
         return containers

--- a/tests/unit/fonds/test_kali.py
+++ b/tests/unit/fonds/test_kali.py
@@ -150,6 +150,82 @@ class TestSearch:
         assert results[0].id == "KALICONT000005635384"
         assert client.call_api.call_count == 2
 
+    def test_hydrates_kalitext_search_hits_via_container_id(self):
+        """Real-world shape: /search returns KALITEXT ids; search()
+        must dispatch through fetch_text, read TexteKali.container_id,
+        then hydrate the enclosing container via fetch_container.
+        """
+        client = MagicMock()
+        client.call_api.side_effect = [
+            _mock_response(200, _search_payload(["KALITEXT000005677408"])),
+            _mock_response(200, _text_payload()),
+            _mock_response(200, _cont_payload("KALICONT000005635384")),
+        ]
+
+        results = KaliAPI(client).search("santé prévoyance")
+
+        assert len(results) == 1
+        assert isinstance(results[0], ConventionCollective)
+        assert results[0].id == "KALICONT000005635384"
+        # 3 API calls: /search, /consult/kaliText, /consult/kaliCont.
+        assert client.call_api.call_count == 3
+        routes = [c.args[0] for c in client.call_api.call_args_list]
+        assert routes == ["search", "consult/kaliText", "consult/kaliCont"]
+
+    def test_skips_kalitext_without_container_id(self):
+        """Orphan KALITEXT case: the text has no idConteneur — there
+        is no way to navigate to a container, so the result is
+        silently dropped. Documented limitation in search() docstring.
+        """
+        orphan_text = dict(_text_payload())
+        orphan_text.pop("idConteneur", None)
+        client = MagicMock()
+        client.call_api.side_effect = [
+            _mock_response(200, _search_payload(["KALITEXT000005644305"])),
+            _mock_response(200, orphan_text),
+        ]
+
+        results = KaliAPI(client).search("avenant isolé")
+
+        assert results == []
+        # No /consult/kaliCont call when container_id is missing.
+        assert client.call_api.call_count == 2
+        routes = [c.args[0] for c in client.call_api.call_args_list]
+        assert routes == ["search", "consult/kaliText"]
+
+    def test_deduplicates_texts_sharing_same_container(self):
+        """N KALITEXT hits under the same convention must cost one
+        /consult/kaliCont call, not N. Regression guard: the dedupe
+        check must happen BEFORE fetch_container is invoked.
+        """
+        client = MagicMock()
+        client.call_api.side_effect = [
+            _mock_response(
+                200,
+                _search_payload(["KALITEXT000005677408", "KALITEXT000005677409"]),
+            ),
+            _mock_response(200, _text_payload()),  # first text → KALICONT000005635384
+            _mock_response(200, _cont_payload("KALICONT000005635384")),
+            _mock_response(200, _text_payload()),  # second text → same container
+            # NO fourth call_api for the container — deduped.
+        ]
+
+        results = KaliAPI(client).search("convention X")
+
+        assert len(results) == 1
+        assert results[0].id == "KALICONT000005635384"
+        # 1 /search + 2 /consult/kaliText + 1 /consult/kaliCont = 4
+        # (NOT 5 — the dedupe must short-circuit before the second
+        # container fetch).
+        assert client.call_api.call_count == 4
+        routes = [c.args[0] for c in client.call_api.call_args_list]
+        assert routes == [
+            "search",
+            "consult/kaliText",
+            "consult/kaliCont",
+            "consult/kaliText",
+        ]
+
     def test_returns_empty_list_on_non_200(self):
         client = MagicMock()
         client.call_api.return_value = _mock_response(500, {})


### PR DESCRIPTION
## Summary

`KaliAPI.search` silently returns `[]` for every real-world query on the KALI fond because it calls `fetch_container(text_id)` on ids that `/search` returns as KALITEXT-prefixed (text-level), not KALICONT-prefixed (container-level). `fetch_container` wraps `POST /consult/kaliCont` which rejects non-KALICONT ids — KALI responds with an empty body and `response.json()` raises `JSONDecodeError`, which the surrounding try/except swallows as a warning.

This PR dispatches each `/search` hit through the existing prefix-routing `fetch()` method and navigates `TexteKali` hits up to their enclosing `ConventionCollective` via `TexteKali.container_id`.

## Root-cause proof

Direct endpoint probe against real KALI on 2026-04-24, using id `KALITEXT000005644305` (observed in the existing warning logs):

| Call | Result |
|---|---|
| `KaliAPI.fetch_container("KALITEXT000005644305")` | `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` |
| `KaliAPI.fetch_text("KALITEXT000005644305")` | populated — `TexteKali(titre="Avenant n° 11 du 5 juin 2000 relatif à la création de C.Q.P. en bureautique et informatique")` |

KALI is healthy; the library was hitting the wrong endpoint.

## Changes

### `pylegifrance/fonds/kali.py::KaliAPI.search`

- Route each `result_id` through `self.fetch(id)` (the existing prefix dispatcher at lines 308-331)
- For `ConventionCollective` entities: use directly
- For `TexteKali` entities: navigate via `entity.container_id` + a second `fetch_container` call
- Skip `KALIARTI` / `KALISCTA` hits (not search-level convention sources)
- Deduplicate by container id. **Dedupe check runs BEFORE `fetch_container` so N text hits under one convention cost 1 extra fetch, not N.**
- Updated docstring to describe the prefix dispatch and note the known limitation

### `tests/unit/fonds/test_kali.py` — three new tests

- `test_hydrates_kalitext_search_hits_via_container_id` — real-world happy path (KALITEXT hit → fetch_text → container_id → fetch_container). Asserts exact route sequence `["search", "consult/kaliText", "consult/kaliCont"]`.
- `test_skips_kalitext_without_container_id` — orphan text (no `idConteneur`): silently dropped, no second endpoint call.
- `test_deduplicates_texts_sharing_same_container` — regression guard: 2 KALITEXT hits → same KALICONT must cost `call_count == 4` (one `/search` + two `/consult/kaliText` + one `/consult/kaliCont`), NOT 5.

The pre-existing `test_hydrates_results_to_containers` (which mocks `/search` returning a KALICONT id) is untouched — that code path remains valid as a defensive branch for any future API shape change.

## Known limitation

A KALITEXT hit whose payload carries no `idConteneur` is silently skipped — there is no other path to the enclosing container from a text alone without an additional API primitive. Isolated avenants may therefore still be absent from search results after this patch. A full resolution would require either a Legifrance-side API complement or a separate convention-listing strategy. Documented in the `search()` docstring under a `Note:` block.

## Test plan

- [x] `uv run pytest tests/unit/fonds/test_kali.py -v` → 23 passed
- [x] `uv run pytest --ignore=tests/integration -q` → 132 passed
- [x] `uv run pre-commit run --all-files` → ruff check / ruff format / ty check all pass
- [ ] Maintainer: please verify against the live PISTE integration tests under `tests/integration/fonds/kali/` with your credentials before merging — I verified the fix against real KALI via a direct probe but did not re-run the full live suite.

## References

- The existing `KaliAPI.fetch(kali_id)` dispatcher at `pylegifrance/fonds/kali.py:308-331` — this PR leans on its prefix routing
- Feature that introduced KALI: #54 (`feat(kali): add façade for conventions collectives`)
- PISTE consult endpoints: `/consult/kaliCont`, `/consult/kaliText`, `/consult/kaliArticle`, `/consult/kaliSection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)