### PR TITLE
fix(kali): TexteKali.container_id falls back to conteneurs[0].cid for avenants

### DIFF
--- a/pylegifrance/fonds/kali.py
+++ b/pylegifrance/fonds/kali.py
@@ -146,12 +146,30 @@ class TexteKali:
     def container_id(self) -> str | None:
         """Identifiant ``KALICONT`` du conteneur parent, si disponible.
 
-        ``ConsultKaliTextResponse`` n'expose pas d'``id`` propre (le
-        schéma DILA l'implique via le contexte d'appel) ; seul
-        ``id_conteneur`` est disponible pour remonter au conteneur
-        parent.
+        Priorité de lecture :
+
+        1. ``id_conteneur`` (``idConteneur`` côté API) — présent pour
+           les textes de base (``typeTexte = "TEXTE_BASE"``).
+        2. ``conteneurs[0].cid`` — présent pour les textes dérivés
+           (avenants, accords). Les avenants retournés par
+           ``/consult/kaliText`` n'ont pas d'``idConteneur`` au niveau
+           racine mais listent leurs conventions parentes dans
+           ``conteneurs`` ; le champ ``cid`` de chaque entrée est
+           l'identifiant ``KALICONT`` canonique.
+
+        Sans ce fallback, ``KaliAPI.search`` (qui navigue texte →
+        conteneur) dropperait tous les avenants retournés par
+        ``/search``, ce qui correspond au cas commun des recherches
+        par secteur puisque la majorité des hits sont des avenants.
         """
-        return self._data.id_conteneur
+        if self._data.id_conteneur:
+            return self._data.id_conteneur
+        conteneurs = self._data.conteneurs
+        if conteneurs:
+            first = conteneurs[0]
+            if first is not None and first.cid:
+                return first.cid
+        return None
 
     @property
     def titre(self) -> str | None:

--- a/tests/unit/fonds/test_kali.py
+++ b/tests/unit/fonds/test_kali.py
@@ -48,6 +48,33 @@ def _text_payload() -> dict:
     }
 
 
+def _avenant_text_payload(cid: str = "KALICONT000005635384") -> dict:
+    """Avenant-shaped KALI text: no top-level ``idConteneur``, parent
+    container referenced only in ``conteneurs[0].cid``.
+
+    Real KALI avenants/accords returned by ``/consult/kaliText`` look
+    like this — see `TexteKali.container_id` docstring for the priority
+    rule this payload exercises.
+    """
+    return {
+        "title": "Avenant n° 1 du 28 novembre 2002 relatif à ...",
+        "etat": "VIGUEUR_ETEN",
+        "typeTexte": "AVENANT",
+        "idConteneur": None,
+        "conteneurs": [
+            {
+                "id": "JORFCONT000038052140",
+                "cid": cid,
+                "titre": "Convention collective nationale parente",
+                "nature": "IDCC",
+                "etat": "VIGUEUR_ETEN",
+            }
+        ],
+        "nor": None,
+        "articles": [],
+    }
+
+
 def _search_payload(ids: list[str]) -> dict:
     return {
         "totalNbResult": len(ids),
@@ -110,6 +137,65 @@ class TestFetchText:
         assert payload == {"id": "KALITEXT000005677408"}
 
 
+class TestTexteKaliContainerId:
+    """`TexteKali.container_id` reads `id_conteneur` first, then falls
+    back to `conteneurs[0].cid`. The fallback is load-bearing for
+    avenants/accords returned by `/search`, which do not carry
+    `idConteneur` at the root but reference their parent convention
+    through `conteneurs`.
+    """
+
+    def test_reads_id_conteneur_when_present(self):
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(200, _text_payload())
+
+        text = KaliAPI(client).fetch_text("KALITEXT000005677408")
+
+        assert text is not None
+        assert text.container_id == "KALICONT000005635384"
+
+    def test_falls_back_to_conteneurs_cid_for_avenants(self):
+        """Real-world avenant shape: idConteneur=None, conteneurs[0].cid
+        carries the parent KALICONT id. Regression guard for the bug
+        where `KaliAPI.search` dropped every avenant result because
+        `container_id` returned None."""
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(
+            200, _avenant_text_payload(cid="KALICONT000005635384")
+        )
+
+        text = KaliAPI(client).fetch_text("KALITEXT000005679954")
+
+        assert text is not None
+        assert text.container_id == "KALICONT000005635384"
+
+    def test_returns_none_when_both_sources_are_empty(self):
+        orphan = dict(_text_payload())
+        orphan.pop("idConteneur", None)
+        orphan["conteneurs"] = []
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(200, orphan)
+
+        text = KaliAPI(client).fetch_text("KALITEXT000009999999")
+
+        assert text is not None
+        assert text.container_id is None
+
+    def test_id_conteneur_wins_over_conteneurs_when_both_present(self):
+        """Priority rule: root `idConteneur` is authoritative when set;
+        `conteneurs[0].cid` is only consulted as a fallback."""
+        mixed = dict(_text_payload())
+        mixed["idConteneur"] = "KALICONT000000000001"
+        mixed["conteneurs"] = [{"cid": "KALICONT999999999999"}]
+        client = MagicMock()
+        client.call_api.return_value = _mock_response(200, mixed)
+
+        text = KaliAPI(client).fetch_text("KALITEXT000000000000")
+
+        assert text is not None
+        assert text.container_id == "KALICONT000000000001"
+
+
 class TestFetchDispatcher:
     @pytest.mark.parametrize(
         ("kali_id", "expected_route"),
@@ -168,6 +254,30 @@ class TestSearch:
         assert isinstance(results[0], ConventionCollective)
         assert results[0].id == "KALICONT000005635384"
         # 3 API calls: /search, /consult/kaliText, /consult/kaliCont.
+        assert client.call_api.call_count == 3
+        routes = [c.args[0] for c in client.call_api.call_args_list]
+        assert routes == ["search", "consult/kaliText", "consult/kaliCont"]
+
+    def test_hydrates_avenant_search_hits_via_conteneurs_fallback(self):
+        """End-to-end regression guard: /search returns a KALITEXT hit
+        that resolves to an avenant (no ``idConteneur`` at the root,
+        parent in ``conteneurs[0].cid``). Before the
+        ``TexteKali.container_id`` fallback was added, search() dropped
+        every such hit under the orphan branch — which was the common
+        case for sector-based queries like "SYNTEC" or "batiment".
+        """
+        client = MagicMock()
+        client.call_api.side_effect = [
+            _mock_response(200, _search_payload(["KALITEXT000005679954"])),
+            _mock_response(200, _avenant_text_payload(cid="KALICONT000005635384")),
+            _mock_response(200, _cont_payload("KALICONT000005635384")),
+        ]
+
+        results = KaliAPI(client).search("SYNTEC")
+
+        assert len(results) == 1
+        assert isinstance(results[0], ConventionCollective)
+        assert results[0].id == "KALICONT000005635384"
         assert client.call_api.call_count == 3
         routes = [c.args[0] for c in client.call_api.call_args_list]
         assert routes == ["search", "consult/kaliText", "consult/kaliCont"]


### PR DESCRIPTION
## Summary

Follow-up to #61. That PR made `KaliAPI.search()` dispatch correctly by id prefix and navigate from text hits to their enclosing container via `TexteKali.container_id`. But `container_id` only read `id_conteneur` (root-level `idConteneur`), which is `null` for avenants — and sector-based search queries return mostly avenants, not base texts. Result: 1.6.2's `search("SYNTEC")` still returned `[]` in practice, even with #61's prefix dispatch in place.

## Root-cause proof

Direct probe on `KALITEXT000005679954` (a SYNTEC avenant from the live search hit list, 2026-04-24):

| Field | Value |
|---|---|
| `text.container_id` | `None` (bug) |
| `text.to_dict()["idConteneur"]` | `None` |
| `text.to_dict()["conteneurs"]` | `[{"cid": "KALICONT...", "id": "JORFCONT...", ...}]` |

The generated model already declares `ConsultKaliTextResponse.conteneurs: list[Conteneur] | None` (`model.py:4344`) and `Conteneur.cid: str | None` (`model.py:602`) — the data was there, just never read.

## Changes

- **`pylegifrance/fonds/kali.py::TexteKali.container_id`** — priority lookup: `id_conteneur` first (TEXTE_BASE path, unchanged), then `conteneurs[0].cid` (avenant / accord path). Returns `None` only if both are empty. Docstring documents the priority rule.

- **`tests/unit/fonds/test_kali.py`** — new fixtures and tests:
  - `_avenant_text_payload()` helper mirroring the real avenant shape
  - `TestTexteKaliContainerId` with 4 cases: primary path intact, the fallback, no-regression on the fully-empty orphan case, and a priority guard (root `idConteneur` wins when both sources present)
  - `TestSearch::test_hydrates_avenant_search_hits_via_conteneurs_fallback` — end-to-end regression guard through the full `/search → /consult/kaliText → /consult/kaliCont` chain

## Test plan

- [x] `uv run pytest tests/unit/fonds/test_kali.py -v` → 28 passed (23 from #61 + 5 new)
- [x] `uv run pytest --ignore=tests/integration -q` → 137 passed
- [x] `uv run pre-commit run --all-files` → ruff check / ruff format / ty check all pass
- [ ] Maintainer: please spot-check against live PISTE with `KaliAPI(client).search("SYNTEC")` — expected to return populated `list[ConventionCollective]` (was returning `[]` on 1.6.2).

## References

- Parent fix: #61 — dispatch search hits by id prefix and navigate to enclosing container
- Generated model: `pylegifrance/models/generated/model.py:4344` (`ConsultKaliTextResponse.conteneurs`) + `:602` (`Conteneur.cid`) — these already existed; this PR just starts reading them

🤖 Generated with [Claude Code](https://claude.com/claude-code)