### PR TITLE
ci: auto-publish via same-workflow needs + align auto-merge with squash convention

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - run: gh pr merge "$PR_URL" --auto --merge
+      - run: gh pr merge "$PR_URL" --auto --squash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,10 @@ name: Release
 on:
   push:
     branches: [main]
-    tags: ["v*", "pylegifrance-v*"]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to publish (e.g. v1.6.0). Required when dispatched manually."
+        description: "Tag to publish (e.g. v1.6.3). Required for manual dispatch (fallback / re-publish)."
         required: true
         type: string
 
@@ -16,39 +15,53 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # release-please: on every push to main, create/update the release PR
+  # and, if the release PR was just merged, create the tag + GitHub
+  # release. Uses the official release-please-action (v4) so its
+  # outputs (``release_created``, ``tag_name``) can drive the publish
+  # job below without relying on a cross-workflow trigger.
   release-please:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       issues: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: actions/setup-node@v4
+      - uses: googleapis/release-please-action@v4
+        id: release
         with:
-          node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/release-please-config.json
+          manifest-file: .github/release-please-manifest.json
 
-      - name: Create or update release PR
-        run: |
-          npx release-please@latest release-pr \
-            --token=${{ secrets.GITHUB_TOKEN }} \
-            --repo-url=${{ github.repository }} \
-            --config-file=.github/release-please-config.json \
-            --manifest-file=.github/release-please-manifest.json
-
-      - name: Tag and create GitHub release
-        run: |
-          npx release-please@latest github-release \
-            --token=${{ secrets.GITHUB_TOKEN }} \
-            --repo-url=${{ github.repository }} \
-            --config-file=.github/release-please-config.json \
-            --manifest-file=.github/release-please-manifest.json
-
+  # publish: build and upload to PyPI. Two entry points:
+  #
+  # 1. Automatic — when release-please created a new release on the
+  #    current push-to-main run. ``needs: [release-please]`` carries
+  #    the tag name through, so no tag-push trigger is needed.
+  #
+  # 2. Manual — ``workflow_dispatch`` with an explicit tag input, used
+  #    as a fallback / re-publish path.
+  #
+  # WHY SAME FILE (not a separate workflow triggered on ``push: tags``):
+  # release-please authenticates via ``GITHUB_TOKEN``. GitHub suppresses
+  # workflow triggers that would be fired by GITHUB_TOKEN-authenticated
+  # actions (its anti-recursion guardrail), so an API-created tag does
+  # NOT fire ``push: tags: ["v*"]`` and a release.published event also
+  # does NOT fire. An inter-job ``needs:`` dependency within a single
+  # workflow file is not gated by that guardrail, so auto-publish works
+  # here without a PAT.
   publish:
+    needs: [release-please]
     if: >-
-      startsWith(github.ref, 'refs/tags/v')
-      || startsWith(github.ref, 'refs/tags/pylegifrance-v')
-      || github.event_name == 'workflow_dispatch'
+      always() && (
+        (needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true')
+        || github.event_name == 'workflow_dispatch'
+      )
     runs-on: self-hosted
     permissions:
       contents: read
@@ -56,10 +69,19 @@ jobs:
     container:
       image: python:3.12
     steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ needs.release-please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout tagged commit
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ steps.tag.outputs.tag }}
 
       - name: Setup Common Environment
         uses: ./.github/actions/setup
@@ -67,11 +89,9 @@ jobs:
           create-env-file: "false"
 
       - name: Check tag vs pyproject version
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          TAG_REF="${INPUT_TAG:-$GITHUB_REF_NAME}"
-          TAG_VERSION="${TAG_REF#pylegifrance-v}"
+          TAG_VERSION="${{ steps.tag.outputs.tag }}"
+          TAG_VERSION="${TAG_VERSION#pylegifrance-v}"
           TAG_VERSION="${TAG_VERSION#v}"
           PROJECT_VERSION=$(awk -F\" '/^version =/ {print $2}' pyproject.toml)
           if [ "$TAG_VERSION" != "$PROJECT_VERSION" ]; then


### PR DESCRIPTION
Two small CI fixes bundled into one PR — both observed as live pain points on 2026-04-24 while shipping 1.6.2 and 1.6.3. Each fix is an atomic commit so either can be reverted independently.

## Commit 1 — auto-publish on release (the important one)

**Bug**: Every release since 1.6.0 has required a manual \`gh workflow run Release -f tag=vX.Y.Z\` step to publish to PyPI. 1.6.1 was released on GitHub but never reached PyPI because the dispatch was forgotten. 1.6.2 and 1.6.3 both required manual dispatch on 2026-04-24 to land.

**Root cause** ([GitHub docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)):

> Events triggered by a workflow run authenticated with \`GITHUB_TOKEN\`, with the exception of \`workflow_dispatch\` and \`repository_dispatch\`, do not create a new workflow run.

\`release-please\` here is authenticated via \`secrets.GITHUB_TOKEN\`, so neither its API-created tag (\`push: tags: ["v*"]\`) nor its API-created release (\`release: types: [published]\`) fires the publish job. The \`workflow_dispatch\` escape hatch added in #57/#58 was a palliative for exactly this.

**Fix**: Keep \`release-please\` and \`publish\` in the same workflow file, wired via \`needs:\` + \`outputs:\`. Inter-job \`needs:\` dependencies are NOT gated by the anti-recursion guardrail.

- Migrated from two-step \`npx release-please {release-pr, github-release}\` to \`googleapis/release-please-action@v4\` so outputs are first-class (\`release_created\`, \`tag_name\`).
- \`publish\` is \`needs: [release-please]\` and gated on \`release_created == 'true'\` for the auto path.
- \`workflow_dispatch\` preserved as fallback / re-publish. The \`always() && (A || B)\` conditional lets it run even when \`release-please\` is skipped (manual dispatch path).
- Dropped the \`push: tags:\` trigger — it was dead code under GITHUB_TOKEN.

**Net effect**: next release PR merge will auto-publish to PyPI. Fallback unchanged.

## Commit 2 — auto-merge strategy fix

**Bug**: \`enable-auto-merge\` has been a failing check on every recent PR (#59, #61, #63) because \`gh pr merge --auto --merge\` asks for merge-commit strategy but the repo allows only squash. Evidence: \`git log --oneline\` since 1.5.0 shows only squash commits with \`(#NN)\` suffix.

**Fix**: \`--merge\` → \`--squash\`.

**Impact**: Removes a recurring red check from the PR UI. Auto-merge is opt-in UX sugar and doesn't gate anything, but it should at least work.

## Test plan

- [x] \`uv run pre-commit run --all-files\` — ruff / ty all pass
- [ ] **Maintainer**: the release auto-publish path can only be exercised end-to-end by the NEXT release PR. Worst case if something in the rewrite is wrong, the fallback \`workflow_dispatch\` path (the status quo) still works — no release would be lost, just the auto step would fail visibly.
- [ ] **Maintainer**: to fast-test, merge this PR, then make any tiny code change on main and observe whether the release-please PR it triggers auto-publishes on merge.

## Rollback

Both commits are independent. If auto-publish misbehaves on the first real release, revert just commit 1 (\`git revert <sha>\`) and the \`workflow_dispatch\` path is restored. Commit 2 is orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)