### PR TITLE
feat(juri): expose sommaire / headnote / bulletin flag on JuriDecision

### DIFF
--- a/pylegifrance/fonds/juri.py
+++ b/pylegifrance/fonds/juri.py
@@ -16,6 +16,7 @@ from pylegifrance.models.generated.model import (
     Operateur,
     RechercheSpecifiqueDTO,
     SearchRequestDTO,
+    TexteSommaire,
     TypeChamp,
     TypePagination,
     TypeRecherche,
@@ -95,6 +96,22 @@ def _normalize_formation(formation: str) -> str:
 # legifrance.gouv.fr.
 JURI_URL_ID_PREFIXES: tuple[str, ...] = ("JURITEXT", "CETATEXT")
 JURI_URL_TEMPLATE = "https://www.legifrance.gouv.fr/juri/id/{decision_id}"
+
+# Cour de cassation bulletin publication categories. Decisions on the JURI
+# fond carry a single-letter code in ``type_publication_bulletin`` indicating
+# their bulletin status. A decision with a non-empty code in this set has
+# been selected for editorial publication — a strong "arrêt de principe"
+# signal in French doctrinal practice. ``"N"`` (or an empty / missing flag)
+# means the decision was not selected.
+#
+# Codes observed on live data and described in the Cour de cassation editorial
+# documentation:
+#
+# - ``P`` — Publié au Bulletin civil / criminel de la Cour de cassation
+# - ``B`` — Bulletin (legacy alias of ``P`` on older records)
+# - ``R`` — Sélectionné pour le Rapport annuel de la Cour de cassation
+# - ``T`` — Cité au Bulletin d'information de la Cour de cassation (BICC)
+PUBLISHED_BULLETIN_CODES: frozenset[str] = frozenset({"P", "B", "R", "T"})
 
 # Canonical Legifrance case-law textId format. A valid JURITEXT or CETATEXT
 # identifier is the literal prefix followed by exactly 12 numeric digits
@@ -258,6 +275,95 @@ class JuriDecision:
         """Récupère la solution de la décision."""
         return getattr(self._decision, "solution", None)
 
+    @property
+    def sommaire(self) -> list[TexteSommaire]:
+        """Récupère la liste des sommaires de la décision.
+
+        Le sommaire est le résumé éditorial canonique d'un arrêt — la
+        synthèse du point de droit tranché, rédigée par les services
+        documentaires de la juridiction. Pour les arrêts de la Cour de
+        cassation publiés au Bulletin, il est l'équivalent d'un *headnote*
+        anglo-saxon. C'est le signal de pertinence le plus précis pour
+        décider si une décision répond à une question juridique donnée
+        (sans avoir à lire le texte intégral).
+
+        Chaque :class:`TexteSommaire` retourné expose en pratique trois
+        champs utiles:
+
+        - ``resume_principal`` — le titre canonique du point de droit
+          (par exemple *"CONTRAT DE TRAVAIL, EXECUTION - Employeur -
+          Coemployeurs - Notion - Critères"*).
+        - ``abstrats`` — le résumé doctrinal en prose, qui décrit la
+          règle dégagée et son application aux faits.
+        - ``autre_resume`` — la taxonomie sous laquelle la décision est
+          classée par la Cour de cassation.
+
+        Returns:
+            La liste des sommaires structurés. Liste vide si la décision
+            n'expose pas de sommaire (cas fréquent pour les juridictions
+            du fond non publiées au Bulletin).
+        """
+        return self._decision.sommaire or []
+
+    @property
+    def headnote(self) -> str | None:
+        """Récupère le titre court du sommaire principal (raccourci).
+
+        Accesseur pratique sur ``sommaire[0].resume_principal``: c'est le
+        champ le plus utile pour un consommateur qui veut lire en une
+        seule phrase de quoi traite la décision. Voir :pyattr:`sommaire`
+        pour les champs plus longs (``abstrats``, ``autre_resume``) et
+        pour les décisions qui exposent plusieurs sommaires.
+
+        Returns:
+            Le ``resume_principal`` du premier sommaire, ou ``None`` si
+            la décision n'expose pas de sommaire ou si ce premier
+            sommaire n'a pas de résumé principal.
+        """
+        for entry in self.sommaire:
+            if entry.resume_principal:
+                return entry.resume_principal
+        return None
+
+    @property
+    def titrages(self) -> list[str]:
+        """Récupère la liste des titrages (taxonomie JURINOME).
+
+        Les titrages sont des chaînes d'identifiants ``JURINOME...``
+        séparés par des tirets, qui codent la position de la décision
+        dans la nomenclature thématique de la Cour de cassation. Utiles
+        pour le routage de pertinence par thème doctrinal sans avoir à
+        analyser le texte de la décision.
+
+        Returns:
+            La liste des titrages. Liste vide si la décision n'expose
+            pas de titrage.
+        """
+        return self._decision.titrages or []
+
+    @property
+    def published_in_bulletin(self) -> bool:
+        """Indique si la décision est publiée dans un bulletin de la juridiction.
+
+        Vrai si ``type_publication_bulletin`` correspond à un code de
+        publication éditoriale (``P``, ``B``, ``R``, ``T`` —
+        cf. :data:`PUBLISHED_BULLETIN_CODES`). Faux si le code est
+        absent, vide, ou explicitement ``"N"`` (non publié).
+
+        Une décision publiée au bulletin a été sélectionnée par les
+        services documentaires de la juridiction comme présentant un
+        intérêt doctrinal — c'est l'un des marqueurs classiques d'un
+        *arrêt de principe* dans la pratique française.
+
+        Returns:
+            ``True`` si la décision est publiée au bulletin, ``False``
+            sinon.
+        """
+        flag = getattr(self._decision, "type_publication_bulletin", None)
+        if not flag:
+            return False
+        return flag.upper() in PUBLISHED_BULLETIN_CODES
+
     def citations(self) -> list["JuriDecision"]:
         """Récupère les citations de la décision.
 
@@ -403,7 +509,17 @@ class JuriDecision:
             parts.append(f"**Référence**: {self.id}")
         if self.url:
             parts.append(f"**URL**: {self.url}")
+        if self.published_in_bulletin:
+            parts.append("**Publié au Bulletin**: oui")
         parts.append("")
+
+        # Surface the canonical editorial summary (sommaire) right above
+        # the body so chunked / token-bounded consumers see the relevance
+        # signal without having to scan the full ruling text.
+        headnote = self.headnote
+        if headnote:
+            parts.append(f"**Sommaire**: {headnote}")
+            parts.append("")
 
         plain = self._extract_plain_text()
         if plain:

--- a/tests/unit/fonds/test_juri_decision.py
+++ b/tests/unit/fonds/test_juri_decision.py
@@ -5,17 +5,26 @@ notably the :pyattr:`JuriDecision.url` auto-generation that mirrors the
 canonical URL logic already present on :class:`Article`.
 """
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from pylegifrance.fonds.juri import JuriDecision
+from pylegifrance.models.generated.model import TexteSommaire
 from pylegifrance.models.juri.models import Decision
 
 
 def _make_decision(decision_id: str | None) -> JuriDecision:
     """Build a :class:`JuriDecision` around a minimally populated model."""
     decision = Decision(id=decision_id) if decision_id is not None else Decision()
+    client = MagicMock()
+    return JuriDecision(decision=decision, client=client)
+
+
+def _make_decision_with(**fields: Any) -> JuriDecision:
+    """Build a :class:`JuriDecision` with arbitrary :class:`Decision` fields."""
+    decision = Decision(**fields)
     client = MagicMock()
     return JuriDecision(decision=decision, client=client)
 
@@ -79,3 +88,172 @@ class TestJuriDecisionUrl:
         assert decision.url is not None
         assert decision.url.startswith("https://www.legifrance.gouv.fr/juri/id/")
         assert decision.url.endswith(decision_id)
+
+
+class TestJuriDecisionSommaire:
+    """Sommaire / headnote / titrages exposure on :class:`JuriDecision`."""
+
+    def test_sommaire_returns_empty_list_when_unset(self):
+        """A decision without a sommaire returns ``[]``, not ``None``."""
+        decision = _make_decision(None)
+
+        assert decision.sommaire == []
+
+    def test_sommaire_returns_list_when_populated(self):
+        """The sommaire list is exposed verbatim, preserving its entries."""
+        entries = [
+            TexteSommaire(
+                id="1",
+                resumePrincipal="Coemployeurs - Notion - Critères",
+                abstrats="Une société d'un groupe ne peut être coemployeur...",
+            ),
+        ]
+        decision = _make_decision_with(sommaire=entries)
+
+        assert decision.sommaire == entries
+        assert decision.sommaire[0].abstrats.startswith("Une société")
+
+    def test_headnote_returns_first_resume_principal(self):
+        """``headnote`` is the convenience accessor on ``sommaire[0].resume_principal``."""
+        entries = [
+            TexteSommaire(id="1", resumePrincipal="Forfait jours - Nullité"),
+            TexteSommaire(id="2", resumePrincipal="Autre point de droit"),
+        ]
+        decision = _make_decision_with(sommaire=entries)
+
+        assert decision.headnote == "Forfait jours - Nullité"
+
+    def test_headnote_skips_empty_resume_principal(self):
+        """``headnote`` returns the first NON-empty ``resume_principal``."""
+        entries = [
+            TexteSommaire(id="1", resumePrincipal=None),
+            TexteSommaire(id="2", resumePrincipal=""),
+            TexteSommaire(id="3", resumePrincipal="Travail de nuit - Repos"),
+        ]
+        decision = _make_decision_with(sommaire=entries)
+
+        assert decision.headnote == "Travail de nuit - Repos"
+
+    def test_headnote_is_none_when_sommaire_missing(self):
+        """A decision without any sommaire has no headnote."""
+        decision = _make_decision(None)
+
+        assert decision.headnote is None
+
+    def test_headnote_is_none_when_all_resume_principal_empty(self):
+        """If every sommaire has an empty ``resume_principal``, headnote is ``None``."""
+        entries = [
+            TexteSommaire(id="1", resumePrincipal=None),
+            TexteSommaire(id="2", resumePrincipal=""),
+        ]
+        decision = _make_decision_with(sommaire=entries)
+
+        assert decision.headnote is None
+
+    def test_titrages_returns_empty_list_when_unset(self):
+        """A decision without titrages returns ``[]``, not ``None``."""
+        decision = _make_decision(None)
+
+        assert decision.titrages == []
+
+    def test_titrages_returns_list_when_populated(self):
+        """Titrages list is exposed verbatim."""
+        titrages = ["JURINOME000007644451-JURINOME000007645245"]
+        decision = _make_decision_with(titrages=titrages)
+
+        assert decision.titrages == titrages
+
+
+class TestJuriDecisionPublishedInBulletin:
+    """Bulletin publication flag on :class:`JuriDecision`."""
+
+    @pytest.mark.parametrize("code", ["P", "B", "R", "T"])
+    def test_published_codes_yield_true(self, code):
+        """Each known editorial-publication code maps to ``True``."""
+        decision = _make_decision_with(typePublicationBulletin=code)
+
+        assert decision.published_in_bulletin is True
+
+    @pytest.mark.parametrize("code", ["p", "b", "r", "t"])
+    def test_lowercase_codes_yield_true(self, code):
+        """Lowercase variants of known codes are accepted (case-insensitive)."""
+        decision = _make_decision_with(typePublicationBulletin=code)
+
+        assert decision.published_in_bulletin is True
+
+    @pytest.mark.parametrize("code", ["N", "n"])
+    def test_explicit_n_yields_false(self, code):
+        """Explicit ``N`` (non publié) maps to ``False``."""
+        decision = _make_decision_with(typePublicationBulletin=code)
+
+        assert decision.published_in_bulletin is False
+
+    def test_missing_flag_yields_false(self):
+        """A decision with no ``type_publication_bulletin`` is not published."""
+        decision = _make_decision(None)
+
+        assert decision.published_in_bulletin is False
+
+    def test_empty_string_flag_yields_false(self):
+        """An empty-string flag is treated as not-published, not as published."""
+        decision = _make_decision_with(typePublicationBulletin="")
+
+        assert decision.published_in_bulletin is False
+
+    def test_unknown_code_yields_false(self):
+        """An unrecognised code is conservatively reported as not-published."""
+        decision = _make_decision_with(typePublicationBulletin="X")
+
+        assert decision.published_in_bulletin is False
+
+
+class TestJuriDecisionToMarkdown:
+    """The Markdown rendering surfaces the headnote and bulletin flag."""
+
+    def test_to_markdown_includes_headnote_when_present(self):
+        """The sommaire's ``resume_principal`` appears as a ``**Sommaire**`` line."""
+        entries = [TexteSommaire(id="1", resumePrincipal="Forfait jours - Nullité")]
+        decision = _make_decision_with(
+            id="JURITEXT000037999394",
+            titre="Cass. soc., 6 juillet 2016",
+            sommaire=entries,
+        )
+
+        rendered = decision.to_markdown()
+
+        assert "**Sommaire**: Forfait jours - Nullité" in rendered
+
+    def test_to_markdown_omits_sommaire_block_when_absent(self):
+        """No ``**Sommaire**`` line when the decision has no headnote."""
+        decision = _make_decision_with(
+            id="JURITEXT000037999394",
+            titre="Cass. soc., 6 juillet 2016",
+        )
+
+        rendered = decision.to_markdown()
+
+        assert "**Sommaire**" not in rendered
+
+    def test_to_markdown_includes_published_in_bulletin_flag(self):
+        """A bulletin-published decision is flagged in the Markdown header."""
+        decision = _make_decision_with(
+            id="JURITEXT000037999394",
+            titre="Cass. soc., 6 juillet 2016",
+            typePublicationBulletin="P",
+        )
+
+        rendered = decision.to_markdown()
+
+        assert "**Publié au Bulletin**: oui" in rendered
+
+    def test_to_markdown_omits_bulletin_flag_when_not_published(self):
+        """An unpublished decision does not get a misleading ``oui`` line."""
+        decision = _make_decision_with(
+            id="JURITEXT000037999394",
+            titre="Cass. soc., 6 juillet 2016",
+            typePublicationBulletin="N",
+        )
+
+        rendered = decision.to_markdown()
+
+        assert "**Publié au Bulletin**" not in rendered


### PR DESCRIPTION
## 📝 Problématique adressée

Le wrapper `JuriDecision` n'expose ni le `sommaire` (le résumé éditorial canonique d'un arrêt) ni le drapeau de publication au bulletin, alors que ces deux champs sont déjà retournés par l'endpoint `consult/juri` et présents sur le modèle `Decision` sous-jacent. Les consommateurs LLM qui souhaitent trier la pertinence d'une décision (typique d'une recherche jurisprudentielle assistée) doivent parser 20-30 KB de texte brut ou casser l'abstraction en accédant à `decision._decision`.

## 💡 Description des changements

Ajout de quatre accesseurs typés sur `JuriDecision`, au même format que les accesseurs existants (`title`, `solution`, `formation`...) :

- **`sommaire: list[TexteSommaire]`** — la liste des sommaires structurés (vide si la décision n'en expose pas).
- **`headnote: str | None`** — raccourci sur `sommaire[0].resume_principal`, le résumé court qui sert de signal de pertinence dans la pratique française (équivalent du *headnote* anglo-saxon).
- **`titrages: list[str]`** — la liste des chaînes JURINOME, utile pour le routage par thème doctrinal.
- **`published_in_bulletin: bool`** — `True` lorsque `type_publication_bulletin` correspond à un code de publication éditoriale (`P`, `B`, `R`, `T`). Marqueur classique d'un *arrêt de principe* dans la doctrine française.

Extension de `to_markdown()` pour faire apparaître le sommaire et le drapeau de publication juste au-dessus du corps du texte, afin que les consommateurs LLM à fenêtre bornée voient le signal de pertinence sans avoir à scanner le texte intégral.

## 🧪 Scénarios de test (BDD)

```gherkin
Fonctionnalité: Exposition du sommaire et du drapeau de publication

  Scénario: Le sommaire d'une décision est exposé
    Étant donné une décision dont le modèle sous-jacent porte un TexteSommaire
    Lorsque j'accède à decision.sommaire
    Alors je récupère la liste des entrées TexteSommaire telle quelle

  Scénario: Le headnote raccourcit l'accès au résumé principal
    Étant donné une décision avec plusieurs sommaires
    Lorsque j'accède à decision.headnote
    Alors je récupère le premier resume_principal non vide

  Scénario: Une décision publiée au Bulletin est correctement détectée
    Étant donné une décision dont type_publication_bulletin vaut "P", "B", "R" ou "T"
    Lorsque j'accède à decision.published_in_bulletin
    Alors je récupère True

  Scénario: Une décision non publiée est correctement détectée
    Étant donné une décision dont type_publication_bulletin vaut "N", est vide, ou absent
    Lorsque j'accède à decision.published_in_bulletin
    Alors je récupère False

  Scénario: La représentation Markdown surface le sommaire et la publication au bulletin
    Étant donné une décision avec un headnote et publiée au Bulletin
    Lorsque j'appelle decision.to_markdown()
    Alors la sortie contient une ligne **Sommaire**: <headnote>
    Et la sortie contient une ligne **Publié au Bulletin**: oui
```

## ✅ Critères d'acceptation

- [x] Les nouvelles propriétés (`sommaire`, `headnote`, `titrages`, `published_in_bulletin`) sont exposées sur `JuriDecision`.
- [x] Les codes de publication au bulletin sont reconnus de manière insensible à la casse (`P`/`p`, etc.) et constants regroupés dans `PUBLISHED_BULLETIN_CODES`.
- [x] `to_markdown()` rend le sommaire et le drapeau de publication.
- [x] Les 25 nouveaux tests unitaires couvrent: liste vide vs non vide, premier `resume_principal` non vide, codes valides/invalides/casse mixte, drapeau manquant, rendu Markdown avec et sans sommaire.
- [x] `uv run pytest tests/unit/` — 156 tests passent.
- [x] `uv run pre-commit run --files ...` — ruff check / format / ty passent.
- [x] Aucune modification du modèle généré (`pylegifrance/models/generated/model.py`) — uniquement l'enveloppe de domaine.

## 📚 Sources doctrinales

L'utilité du sommaire comme signal de pertinence est documentée à la fois côté pratique française et côté littérature *Retrieval-Augmented Generation* :

- [Jurisguide — Méthodologie de la recherche documentaire en droit](https://www.jurisguide.fr/fiches-pedagogiques/methodologie-de-la-recherche-documentaire-en-droit) : étapes de la recherche en droit français — *du général au particulier*, avec lecture du sommaire pour trier la pertinence avant de lire l'arrêt complet.
- [arXiv 2510.06999 (2026) — Towards Reliable Retrieval in RAG Systems for Large Legal Datasets](https://arxiv.org/html/2510.06999v1) : nomme la défaillance dominante (*Document-Level Retrieval Mismatch*, jusqu'à 95% sur des textes standardisés) et identifie le *Summary-Augmented Chunking* (préfixer chaque chunk d'un résumé court ~150 caractères) comme atténuation de premier ordre.