### PR TITLE
ci(auto-merge): grant contents:write so enablePullRequestAutoMerge succeeds

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,6 +8,7 @@ jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - run: gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## 📝 Problématique adressée

Le workflow ``auto-merge.yml`` échoue systématiquement au déclenchement avec ``GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)``. Toute nouvelle PR affiche une CI rouge sur ``enable-auto-merge`` alors même que le vrai gate (``test``) est vert. Constaté sur PR #66.

## 💡 Description des changements

La mutation GraphQL ``enablePullRequestAutoMerge`` exige les deux scopes ``contents: write`` ET ``pull-requests: write`` sur le ``GITHUB_TOKEN`` (parce qu'elle planifie un commit de fusion à venir, donc nécessite des droits sur le contenu du repo). Le workflow n'avait que ``pull-requests: write``.

Ajout de ``contents: write`` aux permissions du job. Aucun autre changement.

Le réglage repo ``Settings → General → Allow auto-merge`` est déjà activé (vérifié via ``gh api repos/pylegifrance/pylegifrance --jq '.allow_auto_merge'`` → ``true``), donc cette permission de workflow est le seul blocage restant.

## 🧪 Scénarios de test (BDD)

```gherkin
Fonctionnalité: Auto-merge sur ouverture de PR

  Scénario: Une PR ouverte active l'auto-merge sans erreur de permission
    Étant donné qu'une PR est ouverte vers ``main``
    Et que l'auto-merge est activé au niveau du repo
    Lorsque le workflow ``auto-merge.yml`` s'exécute
    Alors la mutation ``enablePullRequestAutoMerge`` réussit
    Et le check ``enable-auto-merge`` apparaît en succès
```

## ✅ Critères d'acceptation

- [x] Le workflow ``auto-merge.yml`` déclare ``contents: write`` en plus de ``pull-requests: write``.
- [x] Aucune autre modification dans le diff (un changement, une raison).
- [ ] La prochaine PR ouverte après merge montre ``enable-auto-merge`` ✅ au lieu de ❌ (vérification post-merge).

## 📚 Références

- [GitHub GraphQL — enablePullRequestAutoMerge](https://docs.github.com/en/graphql/reference/mutations#enablepullrequestautomerge)
- [GitHub Actions — GITHUB_TOKEN permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)