### PR TITLE
fix(code): convertir les timestamps epoch en UTC et non en heure locale

### DIFF
--- a/pylegifrance/fonds/code.py
+++ b/pylegifrance/fonds/code.py
@@ -2,7 +2,7 @@ import json
 import logging
 import re
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Self
 
 from pylegifrance import LegifranceClient
@@ -421,7 +421,7 @@ class CodeConsultFetcher:
         if date.isdigit() and len(date) >= 10:
             try:
                 timestamp = int(date) / 1000
-                dt = datetime.fromtimestamp(timestamp)
+                dt = datetime.fromtimestamp(timestamp, tz=UTC)
                 self.date = dt.strftime("%Y-%m-%d")
                 logger.debug(f"Date converted from timestamp to: {self.date}")
                 return self._execute()
@@ -514,7 +514,7 @@ class ArticleFetcher:
             date_str = date.strftime("%Y-%m-%d")
         elif isinstance(date, int):
             # Unix timestamp in milliseconds
-            date_str = datetime.fromtimestamp(date / 1000).strftime("%Y-%m-%d")
+            date_str = datetime.fromtimestamp(date / 1000, tz=UTC).strftime("%Y-%m-%d")
         elif isinstance(date, str):
             # Validate format
             datetime.fromisoformat(date)

--- a/tests/unit/fonds/test_date_conversion.py
+++ b/tests/unit/fonds/test_date_conversion.py
@@ -1,0 +1,32 @@
+"""Unit tests for date conversion in ArticleFetcher."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from pylegifrance.fonds.code import ArticleFetcher
+
+
+class TestArticleFetcherEpochMs:
+    """Légifrance transmet les dates en millisecondes epoch, donc en UTC.
+    Converties en heure locale, elles décalent la date civile d'un jour dans
+    tout fuseau négatif : 1577836800000 (2020-01-01T00:00:00Z) devient
+    2019-12-31 à New York. Les versions d'un article changeant à minuit, la
+    requête porte alors sur la mauvaise version.
+    """
+
+    def test_epoch_ms_converted_as_utc(self, monkeypatch):
+        monkeypatch.setenv("TZ", "America/New_York")
+        time.tzset()
+
+        client = MagicMock()
+        fetcher = ArticleFetcher(client, "LEGIARTI000006419292")
+
+        # La réponse mockée n'est pas exploitable : seule la requête compte.
+        with pytest.raises(ValidationError):
+            fetcher.at(1577836800000)
+
+        request_data = client.call_api.call_args[0][1]
+        assert request_data["date"] == "2020-01-01"


### PR DESCRIPTION
## 📝 Problématique adressée

Légifrance transmet les dates en millisecondes epoch, donc en UTC. Deux conversions dans `fonds/code.py` utilisent le fuseau horaire local, ce qui décale la date civile d'un jour à l'ouest de Greenwich. Les versions d'un article changeant à minuit, la requête porte alors sur la mauvaise version.

## 💡 Description des changements

`datetime.fromtimestamp(..., tz=UTC)` dans `CodeConsultFetcher.at` et `ArticleFetcher.at`. Les deux formatent immédiatement en `%Y-%m-%d` : aucun changement de type exposé.

Le modèle Pydantic (`Article.parse_date`) n'est pas affecté : la coercition de Pydantic attache déjà UTC après le validateur `mode="before"`. Vérifié avant modification.

## 🧪 Scénarios de test (BDD)

```gherkin
Fonctionnalité: Conversion des timestamps epoch
  Scénario: Article demandé à une date frontière depuis un fuseau négatif
    Étant donné un système configuré sur America/New_York
    Lorsque ArticleFetcher.at(1577836800000) est appelé
    Alors la requête doit porter la date 2020-01-01
    Et non 2019-12-31
```

## ✅ Critères d'acceptation

- [x] Les deux conversions utilisent UTC
- [x] Test unitaire échouant sans le correctif (`'2019-12-31' == '2020-01-01'`)
- [x] Aucun changement de comportement en fuseau positif
- [x] Suite complète : 158 passés (baseline 157 + 1)

## Observations hors périmètre

Deux problèmes préexistants sur `main`, non traités ici :

- `ty check` signale 4 diagnostics dans `fonds/loda.py:1194`, présents avant cette PR.
- `conventional-pre-commit` v4.4.0 rejette l'argument `--types` passé par `.pre-commit-config.yaml` : `error: unrecognized arguments: --types`. Le hook ne peut pas s'exécuter en l'état.

Commit effectué avec `SKIP=ty,conventional-pre-commit`.


## 🤖 Prompt LLM utilisé

Cette contribution n'est pas issue d'un prompt unique mais d'une session
itérative avec Claude (analyse du code, formulation du correctif, rédaction
du test). Les prompts déterminants :

> Ce projet enveloppe la même API PISTE qu'un travail que je mène. Lis le
> code et réponds précisément, en citant fichier et ligne : comment les dates
> sont-elles normalisées ? Les millisecondes epoch et l'ISO avec décalage
> sont-elles toutes deux traitées ? La question UTC vs date civile est-elle
> prise en compte ?

> Écris un test unitaire qui échoue sans le correctif. Il doit forcer un
> fuseau négatif et vérifier la date portée par la requête, pas la réponse.

Le diagnostic initial visait aussi `models/code/models.py`. Vérification
faite, la coercition Pydantic y attache déjà UTC : le modèle a été retiré du
périmètre.
