### PR TITLE
ci: pass commit types as positional args to conventional-pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,17 @@ repos:
         stages: [commit-msg]
         args:
           - --strict
-          - --types
-          - build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+          - build
+          - chore
+          - ci
+          - docs
+          - feat
+          - fix
+          - perf
+          - refactor
+          - revert
+          - style
+          - test
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11


### PR DESCRIPTION
## Problème

`conventional-pre-commit` v4 a supprimé le flag `--types` : les types autorisés sont désormais des arguments positionnels. Avec l'ancienne configuration, le hook `commit-msg` échouait sur chaque commit :

```
conventional-pre-commit: error: unrecognized arguments: --types
```

(Signalé comme observation hors périmètre dans #70.)

## Changement

Les types passent en arguments positionnels après `--strict`, même liste qu'avant (release-please + `revert`).

Vérifié : message conforme accepté, message non conforme et type inconnu rejetés.

## References

- https://github.com/compilerla/conventional-pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)