### PR TITLE
test: skip integration tests when Legifrance credentials are absent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,33 @@
+import os
+
 import pytest
+from dotenv import load_dotenv
 
 from pylegifrance.client import LegifranceClient
 from pylegifrance.config import ApiConfig
+
+load_dotenv()
+
+
+def credentials_available() -> bool:
+    """Check whether Legifrance API credentials are configured."""
+    return bool(
+        os.getenv("LEGIFRANCE_CLIENT_ID") and os.getenv("LEGIFRANCE_CLIENT_SECRET")
+    )
+
+
+requires_credentials = pytest.mark.skipif(
+    not credentials_available(),
+    reason="Legifrance credentials not configured (fork PRs run without secrets)",
+)
 
 
 @pytest.fixture(scope="module")
 def api_client() -> LegifranceClient:
     """Create a real Legifrance client for integration tests."""
+    if not credentials_available():
+        pytest.skip(
+            "Legifrance credentials not configured (fork PRs run without secrets)"
+        )
     config = ApiConfig.from_env()
     return LegifranceClient(config=config)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,8 +6,10 @@ from dotenv import load_dotenv
 
 from pylegifrance.client import LegifranceClient
 from pylegifrance.config import ApiConfig
+from tests.conftest import requires_credentials
 
 
+@requires_credentials
 @pytest.mark.parametrize(
     "config_type,description",
     [
@@ -61,6 +63,7 @@ def test_client_initialization_without_env_vars(monkeypatch):
     assert "Required environment variables" in str(excinfo.value)
 
 
+@requires_credentials
 def test_update_api_keys_with_valid_credentials(monkeypatch):
     """
     Test that update_api_keys replaces invalid credentials with valid ones from env.
@@ -97,6 +100,7 @@ def test_ping_success(api_client):
     assert success is True, "Ping should return True for a valid API connection."
 
 
+@requires_credentials
 def test_session_context_manager():
     """
     Test the session context manager.


### PR DESCRIPTION
## Problème

GitHub ne transmet pas les secrets du dépôt aux workflows `pull_request` déclenchés depuis un fork. Sur chaque PR externe (ex. #70), les 52 tests d'intégration échouent avec `Required environment variables LEGIFRANCE_CLIENT_ID and/or LEGIFRANCE_CLIENT_SECRET are not set`, alors que les tests unitaires passent.

## Changement

- `tests/conftest.py` : la fixture `api_client` skippe proprement quand les identifiants sont absents ; ajout du helper `credentials_available()` et du marqueur `requires_credentials`.
- `tests/test_client.py` : les 4 tests qui instancient un client réel directement portent le marqueur.

Les PR de forks sont ainsi validées sur les tests unitaires ; la suite complète continue de tourner sur les branches internes et à chaque push sur `main`.

L'alternative `pull_request_target` (checkout de code non fiable avec secrets) est explicitement déconseillée par GitHub, a fortiori sur runner self-hosted.

## Vérification

- Sans identifiants (simulation PR de fork) : **157 passed, 52 skipped**
- Avec identifiants : **209 passed**

## References

- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
- https://docs.pytest.org/en/stable/how-to/skipping.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)