### PR TITLE
refactor(loda): annotate consult_response_data as dict[str, Any]

### DIFF
--- a/pylegifrance/fonds/loda.py
+++ b/pylegifrance/fonds/loda.py
@@ -1154,7 +1154,7 @@ class Loda:
         """
         try:
             # Création des données de base pour la réponse
-            consult_response_data = {"id": text_id, "title": title_text}
+            consult_response_data: dict[str, Any] = {"id": text_id, "title": title_text}
 
             # Extraction des métadonnées
             self._extract_date_from_text_id(text_id, consult_response_data)


### PR DESCRIPTION
## Problème

`uvx ty check` signalait 4 diagnostics `invalid-argument-type` sur `pylegifrance/fonds/loda.py:1194` : ty infère `dict[str, str]` depuis le littéral initial de `consult_response_data`, donc l'unpacking `ConsultTextResponse(**filtered_data)` fait apparaître `str` comme non assignable aux champs itérables (articles, sections, dossiers législatifs, liens).

## Changement

Annotation `dict[str, Any]` au point d'origine (ligne 1157). C'est le type réel : les helpers d'extraction (déjà typés `dict[str, Any]`) y accumulent des `str` et des `datetime`. Aucun changement de comportement.

## Vérification

- `uvx ty check` : **0 diagnostic** (4 avant)
- `uvx ruff check` + `format --check` : OK
- `uv run pytest tests/unit` : 157 passed

Le hook pre-commit `ty` peut désormais tourner sans `SKIP` sur les changements Python.

## References

- https://docs.python.org/3/library/typing.html#typing.Any
- https://github.com/astral-sh/ty

🤖 Generated with [Claude Code](https://claude.com/claude-code)